### PR TITLE
docs: Update LICENSE with correct copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Coze
+Copyright (c) 2023 Spring (SG) Pte. Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Changed copyright from "Coze" to "Spring (SG) Pte. Ltd."
- Improved legal accuracy and compliance