### PR TITLE
refactor: Simplify code by removing getargs and getorigin

### DIFF
--- a/cozepy/request.py
+++ b/cozepy/request.py
@@ -46,16 +46,16 @@ class Requester(object):
         self._client = client
 
     def request(
-            self,
-            method: str,
-            url: str,
-            model: Union[Type[T], Iterable[Type[T]], None],
-            params: dict = None,
-            headers: dict = None,
-            body: dict = None,
-            files: dict = None,
-            stream: bool = False,
-            data_field: str = "data",
+        self,
+        method: str,
+        url: str,
+        model: Union[Type[T], Iterable[Type[T]], None],
+        params: dict = None,
+        headers: dict = None,
+        body: dict = None,
+        files: dict = None,
+        stream: bool = False,
+        data_field: str = "data",
     ) -> Union[T, List[T], Iterator[str], None]:
         """
         Send a request to the server.
@@ -100,13 +100,13 @@ class Requester(object):
         pass
 
     def _make_request(
-            self,
-            method: str,
-            url: str,
-            params: dict = None,
-            headers: dict = None,
-            json: dict = None,
-            files: dict = None,
+        self,
+        method: str,
+        url: str,
+        params: dict = None,
+        headers: dict = None,
+        json: dict = None,
+        files: dict = None,
     ) -> httpx.Request:
         if headers is None:
             headers = {}

--- a/cozepy/request.py
+++ b/cozepy/request.py
@@ -1,13 +1,14 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    Iterable,
     Iterator,
     List,
     Optional,
     Tuple,
     Type,
     TypeVar,
-    Union, Iterable,
+    Union,
 )
 
 import httpx

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,9 +1,9 @@
 import time
 
 from tests.config import (
-    app_oauth,
     COZE_JWT_AUTH_KEY_ID,
     COZE_JWT_AUTH_PRIVATE_KEY,
+    app_oauth,
     jwt_auth,
 )
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,7 +1,7 @@
 import os
 from unittest import TestCase
 
-from cozepy import Coze, COZE_CN_BASE_URL
+from cozepy import COZE_CN_BASE_URL, Coze
 from tests.config import fixed_token_auth, jwt_auth
 
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cozepy import Coze, COZE_CN_BASE_URL
+from cozepy import COZE_CN_BASE_URL, Coze
 from tests.config import fixed_token_auth
 
 


### PR DESCRIPTION
- Removed `get_args` and `get_origin` methods
- Replaced `List` with `Iterable` for simpler code