### PR TITLE
feat: Add bot restriction support in JWT OAuth app

### DIFF
--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -7,6 +7,7 @@ from .auth import (
     OAuthApp,
     OAuthToken,
     PKCEOAuthApp,
+    Scope,
     TokenAuth,
 )
 from .bots import (
@@ -84,6 +85,7 @@ __all__ = [
     "Auth",
     "TokenAuth",
     "JWTAuth",
+    "Scope",
     # bots
     "BotPromptInfo",
     "BotOnboardingInfo",


### PR DESCRIPTION
- Enhanced `JWTOAuthApp` to allow setting restrictions on specific bots during token request
- Improved security and control over bot interactions in the chat application