### PR TITLE
feat: Add iteration support to paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ pip install cozepy
 
 #### Fixed Auth Token
 
-create Personal Auth Token at [扣子](https://www.coze.cn/open/oauth/pats) or [Coze Platform](https://www.coze.com/open/oauth/pats)
+create Personal Auth Token at [扣子](https://www.coze.cn/open/oauth/pats)
+or [Coze Platform](https://www.coze.com/open/oauth/pats)
 
 and use `TokenAuth` to init Coze client.
 
@@ -37,7 +38,8 @@ coze = Coze(auth=TokenAuth("your_token"))
 
 #### JWT OAuth App
 
-create JWT OAuth App at [扣子](https://www.coze.cn/open/oauth/apps) or [Coze Platform](https://www.coze.com/open/oauth/apps)
+create JWT OAuth App at [扣子](https://www.coze.cn/open/oauth/apps)
+or [Coze Platform](https://www.coze.com/open/oauth/apps)
 
 ```python
 from cozepy import Coze, JWTAuth
@@ -337,7 +339,8 @@ url = pkce_oauth_app.get_oauth_url(redirect_uri='http://127.0.0.1:8080', state='
 # After authorization, you can exchange code_verifier for access token
 code = 'mock code'
 
-oauth_token = pkce_oauth_app.get_access_token(redirect_uri='http://127.0.0.1:8080', code=code, code_verifier=code_verifier)
+oauth_token = pkce_oauth_app.get_access_token(redirect_uri='http://127.0.0.1:8080', code=code,
+                                              code_verifier=code_verifier)
 
 # use the access token to init Coze client
 coze = Coze(auth=TokenAuth(oauth_token.access_token))
@@ -432,6 +435,7 @@ from cozepy import Coze, TokenAuth, Stream, WorkflowEvent, WorkflowEventType
 
 coze = Coze(auth=TokenAuth("your_token"))
 
+
 def handle_workflow_iterator(stream: Stream[WorkflowEvent]):
     for event in stream:
         if event.event == WorkflowEventType.MESSAGE:
@@ -477,6 +481,91 @@ async def main():
     async for event in stream:
         if event.event == ChatEventType.CONVERSATION_MESSAGE_DELTA:
             print('got message delta:', event.message.content)
+
+
+asyncio.run(main())
+```
+
+### Paginator Iterator
+
+The result returned by all list interfaces (both synchronous and asynchronous) is a paginator, which supports iteration.
+
+Take the example of listing the bots in a space to explain the three ways to use the paginator iterator:
+
+#### 1. Not using iterators
+
+```python
+from cozepy import Coze, TokenAuth
+
+coze = Coze(auth=TokenAuth("your_token"))
+
+bots_page = coze.bots.list(space_id='space id', page_size=10)
+bots = bots_page.items
+total = bots_page.total
+has_more = bots_page.has_more
+```
+
+#### 2. Iterate over the paginator, getting T
+
+```python
+from cozepy import Coze, TokenAuth
+
+coze = Coze(auth=TokenAuth("your_token"))
+
+bots_page = coze.bots.list(space_id='space id', page_size=10)
+for bot in bots_page:
+    print('got bot:', bot)
+```
+
+Asynchronous methods also support:
+
+```python
+import asyncio
+
+from cozepy import TokenAuth, AsyncCoze
+
+coze = AsyncCoze(auth=TokenAuth("your_token"))
+
+
+async def main():
+    bots_page = await coze.bots.list(space_id='space id', page_size=10)
+    async for bot in bots_page:
+        print('got bot:', bot)
+
+
+asyncio.run(main())
+```
+
+#### 3. Iterate over the paginator iter_pages to get the next page paginator
+
+```python
+from cozepy import Coze, TokenAuth
+
+coze = Coze(auth=TokenAuth("your_token"))
+
+bots_page = coze.bots.list(space_id='space id', page_size=10)
+for page in bots_page.iter_pages():
+    print('got page:', page.page_num)
+    for bot in page.items:
+        print('got bot:', bot)
+```
+
+Asynchronous methods also support:
+
+```python
+import asyncio
+
+from cozepy import TokenAuth, AsyncCoze
+
+coze = AsyncCoze(auth=TokenAuth("your_token"))
+
+
+async def main():
+    bots_page = await coze.bots.list(space_id='space id', page_size=10)
+    async for page in bots_page.iter_pages():
+        print('got page:', page.page_num)
+        for bot in page.items:
+            print('got bot:', bot)
 
 
 asyncio.run(main())

--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -60,11 +60,15 @@ from .knowledge.documents import (
 )
 from .log import setup_logging
 from .model import (
+    AsyncLastIDPaged,
+    AsyncNumberPaged,
+    AsyncPagedBase,
     AsyncStream,
     LastIDPaged,
+    LastIDPagedResponse,
     NumberPaged,
+    NumberPagedResponse,
     Stream,
-    TokenPaged,
 )
 from .request import AsyncHTTPClient, SyncHTTPClient
 from .version import VERSION
@@ -160,11 +164,15 @@ __all__ = [
     "CozePKCEAuthError",
     "CozePKCEAuthErrorType",
     # model
+    "AsyncLastIDPaged",
+    "AsyncNumberPaged",
+    "AsyncPagedBase",
     "AsyncStream",
     "LastIDPaged",
+    "LastIDPagedResponse",
     "NumberPaged",
+    "NumberPagedResponse",
     "Stream",
-    "TokenPaged",
     # request
     "SyncHTTPClient",
     "AsyncHTTPClient",

--- a/cozepy/model.py
+++ b/cozepy/model.py
@@ -1,71 +1,410 @@
-from typing import AsyncIterator, Callable, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
+import abc
+from typing import (
+    TYPE_CHECKING,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
+import httpx
 from pydantic import BaseModel, ConfigDict
 
 from cozepy.exception import CozeEventError
 
+if TYPE_CHECKING:
+    from cozepy.request import Requester
+
 T = TypeVar("T")
+SyncPage = TypeVar("SyncPage", bound="PagedBase")
+AsyncPage = TypeVar("AsyncPage", bound="AsyncPagedBase")
 
 
 class CozeModel(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class PagedBase(Generic[T]):
-    """
-    list api result base.
-    """
+class HTTPRequest(CozeModel, Generic[T]):
+    method: str
+    url: str
+    params: Optional[dict] = None
+    headers: Optional[dict] = None
+    json_body: Optional[dict] = None
+    files: Optional[dict] = None
+    is_async: Optional[bool] = None
+    stream: bool = False
+    data_field: str = "data"
+    cast: Union[Type[T], List[Type[T]], None] = None
 
-    def __init__(self, items: List[T], has_more: bool):
-        self.items = items
-        self.has_more = has_more
+    @property
+    def as_httpx(self) -> httpx.Request:
+        return httpx.Request(
+            method=self.method,
+            url=self.url,
+            params=self.params,
+            headers=self.headers,
+            json=self.json_body,
+            files=self.files,
+        )
 
 
-class TokenPaged(PagedBase[T]):
-    """
-    list api, which params is page_token + page_size,
-    return is next_page_token + has_more.
-    """
+class PagedBase(Generic[T], abc.ABC):
+    @abc.abstractmethod
+    def iter_pages(self: SyncPage) -> Iterator[SyncPage]:
+        raise NotImplementedError
 
-    def __init__(self, items: List[T], next_page_token: str = "", has_more: Optional[bool] = None):
-        has_more = has_more if has_more is not None else next_page_token != ""
-        super().__init__(items, has_more)
-        self.next_page_token = next_page_token
+    @property
+    @abc.abstractmethod
+    def items(self) -> List[T]:
+        raise NotImplementedError
 
-    def __repr__(self):
-        return f"TokenPaged(items={self.items}, next_page_token={self.next_page_token})"
+    @property
+    @abc.abstractmethod
+    def has_more(self) -> bool:
+        raise NotImplementedError
+
+
+class AsyncPagedBase(Generic[T], abc.ABC):
+    @abc.abstractmethod
+    def iter_pages(self: AsyncPage) -> AsyncIterator[AsyncPage]:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def items(self) -> List[T]:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def has_more(self) -> bool:
+        raise NotImplementedError
+
+
+class NumberPagedResponse(Generic[T], abc.ABC):
+    @abc.abstractmethod
+    def get_total(self) -> int:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_items(self) -> List[T]:
+        raise NotImplementedError
 
 
 class NumberPaged(PagedBase[T]):
-    def __init__(self, items: List[T], page_num: int, page_size: int, total: Optional[int] = None):
-        has_more = len(items) >= page_size
-        super().__init__(items, has_more)
+    def __init__(
+        self,
+        page_num: int,
+        page_size: int,
+        requestor: "Requester",
+        request_maker: Callable[[int, int], HTTPRequest],
+    ):
         self.page_num = page_num
         self.page_size = page_size
-        self.total = total
 
-    def __repr__(self):
-        return (
-            f"NumberPaged(items={self.items}, page_num={self.page_num}, page_size={self.page_size}, total={self.total})"
+        self._total = None
+        self._items = None
+
+        self._requestor = requestor
+        self._request_maker = request_maker
+
+        self._fetch_page()
+
+    def __iter__(self) -> Iterator[T]:  # type: ignore
+        for page in self.iter_pages():
+            for item in page.items:
+                yield item
+
+    def iter_pages(self) -> Iterator["NumberPaged[T]"]:
+        yield self
+
+        page_num = self.page_num
+        while self.total > page_num * self.page_size:
+            page_num += 1
+            yield NumberPaged(
+                page_num=page_num,
+                page_size=self.page_size,
+                requestor=self._requestor,
+                request_maker=self._request_maker,
+            )
+
+    @property
+    def items(self) -> List[T]:
+        return self._items or cast(List[T], [])
+
+    @property
+    def has_more(self) -> bool:
+        if self._items and len(self._items) >= self.page_size:
+            return True
+        return False
+
+    @property
+    def total(self) -> int:
+        return self._total or 0
+
+    def _fetch_page(self):
+        if self._total is not None:
+            return
+        request: HTTPRequest = self._request_maker(self.page_num, self.page_size)
+        res: NumberPagedResponse[T] = self._requestor.send(request)
+        self._total = res.get_total()
+        self._items = res.get_items()
+
+
+class AsyncNumberPaged(AsyncPagedBase[T]):
+    def __init__(
+        self,
+        page_num: int,
+        page_size: int,
+        requestor: "Requester",
+        request_maker: Callable[[int, int], HTTPRequest],
+    ):
+        self.page_num = page_num
+        self.page_size = page_size
+
+        self._total = None
+        self._items = None
+
+        self._requestor = requestor
+        self._request_maker = request_maker
+
+    async def __aiter__(self) -> AsyncIterator[T]:
+        async for page in self.iter_pages():
+            for item in page.items:
+                yield item
+
+    async def iter_pages(self) -> AsyncIterator["AsyncNumberPaged[T]"]:
+        yield self
+
+        page_num = self.page_num
+        while self.total > page_num * self.page_size:
+            page_num += 1
+            page: AsyncNumberPaged[T] = await AsyncNumberPaged.build(
+                page_num=page_num,
+                page_size=self.page_size,
+                requestor=self._requestor,
+                request_maker=self._request_maker,
+            )
+            yield page
+
+    @property
+    def items(self) -> List[T]:
+        return self._items or cast(List[T], [])
+
+    @property
+    def has_more(self) -> bool:
+        if self._items and len(self._items) >= self.page_size:
+            return True
+        return False
+
+    @property
+    def total(self) -> int:
+        return self._total or 0
+
+    async def _fetch_page(self):
+        """
+
+        :rtype: object
+        """
+        if self._total is not None:
+            return
+        request = self._request_maker(self.page_num, self.page_size)
+        res: NumberPagedResponse[T] = await self._requestor.asend(request)
+        self._total = res.get_total()
+        self._items = res.get_items()
+
+    @staticmethod
+    async def build(
+        page_num: int,
+        page_size: int,
+        requestor: "Requester",
+        request_maker: Callable[[int, int], HTTPRequest],
+    ) -> "AsyncNumberPaged[T]":
+        page: AsyncNumberPaged[T] = AsyncNumberPaged(
+            page_num=page_num,
+            page_size=page_size,
+            requestor=requestor,
+            request_maker=request_maker,
         )
+        await page._fetch_page()
+        return page
+
+
+class LastIDPagedResponse(Generic[T], abc.ABC):
+    @abc.abstractmethod
+    def get_first_id(self) -> str: ...
+
+    @abc.abstractmethod
+    def get_last_id(self) -> str: ...
+
+    @abc.abstractmethod
+    def get_has_more(self) -> bool: ...
+
+    @abc.abstractmethod
+    def get_items(self) -> List[T]: ...
 
 
 class LastIDPaged(PagedBase[T]):
     def __init__(
         self,
-        items: List[T],
-        first_id: str = "",
-        last_id: str = "",
-        has_more: Optional[bool] = None,
+        before_id: str,
+        after_id: str,
+        requestor: "Requester",
+        request_maker: Callable[[str, str], HTTPRequest],
     ):
-        has_more = has_more if has_more is not None else last_id != ""
-        super().__init__(items, has_more)
-        self.first_id = first_id
-        self.last_id = last_id
-        self.has_more = has_more
+        self.before_id = before_id
+        self.after_id = after_id
+        self.first_id: Optional[str] = None
+        self.last_id: Optional[str] = None
+        self._has_more: Optional[bool] = None
+        self._items: Optional[List[T]] = None
 
-    def __repr__(self):
-        return f"LastIDPaged(items={self.items}, first_id={self.first_id}, last_id={self.last_id}, has_more={self.has_more})"
+        self._requestor = requestor
+        self._request_maker = request_maker
+
+        self._fetch_page()
+
+    def __iter__(self) -> Iterator[T]:  # type: ignore
+        for page in self.iter_pages():
+            for item in page.items:
+                yield item
+
+    def iter_pages(self) -> Iterator["LastIDPaged[T]"]:
+        yield self
+
+        has_more = self._has_more
+        last_id = self.last_id
+        while self._check_has_more(has_more, last_id):
+            page: LastIDPaged[T] = LastIDPaged(
+                before_id="",
+                after_id=last_id or "",
+                requestor=self._requestor,
+                request_maker=self._request_maker,
+            )
+            has_more = page.has_more
+            last_id = page.last_id
+            yield page
+
+    @property
+    def items(self) -> List[T]:
+        return self._items or []
+
+    @property
+    def has_more(self) -> bool:
+        if self._has_more is not None:
+            return self._has_more
+        return self.after_id != ""
+
+    def _fetch_page(self):
+        if self.last_id is not None or self._has_more is not None:
+            return
+
+        request = self._request_maker(self.before_id, self.after_id)
+        res: LastIDPagedResponse[T] = self._requestor.send(request)
+
+        self.first_id = res.get_first_id()
+        self.last_id = res.get_last_id()
+        self._has_more = res.get_has_more()
+        self._items = res.get_items()
+
+    def _check_has_more(self, has_more: Optional[bool] = None, last_id: Optional[str] = None) -> bool:
+        if has_more is not None:
+            return has_more
+        if last_id and last_id != "":
+            return True
+        return False
+
+
+class AsyncLastIDPaged(AsyncPagedBase[T]):
+    def __init__(
+        self,
+        before_id: str,
+        after_id: str,
+        requestor: "Requester",
+        request_maker: Callable[[str, str], HTTPRequest],
+    ):
+        self.before_id = before_id
+        self.after_id = after_id
+        self.first_id = None
+        self.last_id = None
+        self._has_more = None
+        self._items: List[T] = []
+
+        self._requestor = requestor
+        self._request_maker = request_maker
+
+    async def __aiter__(self) -> AsyncIterator[T]:
+        async for page in self.iter_pages():
+            for item in page.items:
+                yield item
+
+    async def iter_pages(self) -> AsyncIterator["AsyncLastIDPaged[T]"]:
+        yield self
+
+        has_more = self._has_more
+        last_id = self.last_id
+        while self._check_has_more(has_more, last_id):
+            page: AsyncLastIDPaged[T] = await AsyncLastIDPaged.build(
+                before_id="",
+                after_id=last_id or "",
+                requestor=self._requestor,
+                request_maker=self._request_maker,
+            )
+            has_more = page.has_more
+            last_id = page.last_id
+            yield page
+
+    @property
+    def items(self) -> List[T]:
+        return self._items
+
+    @property
+    def has_more(self) -> bool:
+        if self._has_more is not None:
+            return self._has_more
+        return self.after_id != ""
+
+    @staticmethod
+    async def build(
+        before_id: str,
+        after_id: str,
+        requestor: "Requester",
+        request_maker: Callable[[str, str], HTTPRequest],
+    ) -> "AsyncLastIDPaged[T]":
+        page: AsyncLastIDPaged = AsyncLastIDPaged(
+            before_id=before_id,
+            after_id=after_id,
+            requestor=requestor,
+            request_maker=request_maker,
+        )
+        await page._fetch_page()
+        return page
+
+    async def _fetch_page(self):
+        if self.last_id is not None or self._has_more is not None:
+            return
+
+        request = self._request_maker(self.before_id, self.after_id)
+        res: LastIDPagedResponse[T] = await self._requestor.asend(request)
+
+        self.first_id = res.get_first_id()
+        self.last_id = res.get_last_id()
+        self._has_more = res.get_has_more()
+        self._items = res.get_items()
+
+    def _check_has_more(self, has_more: Optional[bool] = None, last_id: Optional[str] = None) -> bool:
+        if has_more is not None:
+            return has_more
+        if last_id and last_id != "":
+            return True
+        return False
 
 
 class Stream(Generic[T]):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,22 +2,11 @@ from typing import Dict
 
 import pytest
 
-from cozepy import CozeEventError, LastIDPaged, NumberPaged, Stream, TokenPaged
+from cozepy import CozeEventError, Stream
 from cozepy.model import AsyncStream
 from cozepy.util import anext
 
 from .test_util import to_async_iterator
-
-
-def test_page_mode():
-    page = TokenPaged(["a", "b", "c"], "next_page", True)
-    assert f"{page}" == "TokenPaged(items=['a', 'b', 'c'], next_page_token=next_page)"
-
-    page = NumberPaged(["a", "b", "c"], 1, 3, 100)
-    assert f"{page}" == "NumberPaged(items=['a', 'b', 'c'], page_num=1, page_size=3, total=100)"
-
-    page = LastIDPaged(["a", "b", "c"], 1, 3, True)
-    assert f"{page}" == "LastIDPaged(items=['a', 'b', 'c'], first_id=1, last_id=3, has_more=True)"
 
 
 def mock_sync_handler(d: Dict[str, str]):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -49,7 +49,7 @@ data: {}
 
 @pytest.mark.respx(base_url="https://api.coze.com")
 class TestWorkflowsRuns:
-    def test_create(self, respx_mock):
+    def test_sync_workflows_runs_create(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/run").mock(
@@ -60,7 +60,7 @@ class TestWorkflowsRuns:
         assert res
         assert res.data == "data"
 
-    def test_stream(self, respx_mock):
+    def test_sync_workflows_runs_stream(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/stream_run").mock(httpx.Response(200, content=stream_testdata))
@@ -70,7 +70,7 @@ class TestWorkflowsRuns:
         assert events
         assert len(events) == 9
 
-    def test_resume(self, respx_mock):
+    def test_sync_workflows_runs_resume(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/stream_resume").mock(httpx.Response(200, content=stream_testdata))
@@ -87,7 +87,7 @@ class TestWorkflowsRuns:
         assert events
         assert len(events) == 9
 
-    def test_stream_invalid_event(self, respx_mock):
+    def test_sync_workflows_runs_invalid_stream_event(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/stream_resume").mock(
@@ -114,7 +114,7 @@ data:{}""",
 @pytest.mark.respx(base_url="https://api.coze.com")
 @pytest.mark.asyncio
 class TestAsyncWorkflowsRuns:
-    async def test_workflows_runs_create(self, respx_mock):
+    async def test_async_workflows_runs_create(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/run").mock(
@@ -153,7 +153,7 @@ class TestAsyncWorkflowsRuns:
         assert events
         assert len(events) == 9
 
-    async def test_workflows_runs_stream_invalid_event(self, respx_mock):
+    async def test_async_workflows_runs_invalid_stream_event(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         respx_mock.post("/v1/workflow/stream_resume").mock(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,64 +4,122 @@ import pytest
 from cozepy import AsyncCoze, Coze, TokenAuth, Workspace, WorkspaceRoleType, WorkspaceType
 
 
+def mock_get_workspace_list(respx_mock, total, page, idx):
+    respx_mock.get(
+        "/v1/workspaces",
+        params={
+            "page_num": page,
+        },
+    ).mock(
+        httpx.Response(
+            200,
+            json={
+                "data": {
+                    "total_count": total,
+                    "workspaces": [
+                        Workspace(
+                            id=f"id_{idx}" if idx else "id",
+                            name="name",
+                            icon_url="icon_url",
+                            role_type=WorkspaceRoleType.ADMIN,
+                            workspace_type=WorkspaceType.PERSONAL,
+                        ).model_dump()
+                    ],
+                }
+            },
+        )
+    )
+
+
 @pytest.mark.respx(base_url="https://api.coze.com")
 class TestWorkspace:
-    def test_list(self, respx_mock):
+    def test_sync_workspaces_list(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        respx_mock.get("/v1/workspaces").mock(
-            httpx.Response(
-                200,
-                json={
-                    "data": {
-                        "total_count": 1,
-                        "workspaces": [
-                            Workspace(
-                                id="id",
-                                name="name",
-                                icon_url="icon_url",
-                                role_type=WorkspaceRoleType.ADMIN,
-                                workspace_type=WorkspaceType.PERSONAL,
-                            ).model_dump()
-                        ],
-                    }
-                },
-            )
-        )
+        mock_get_workspace_list(respx_mock, total=1, page=1, idx=0)
 
         res = coze.workspaces.list()
 
         assert res
         assert res.items[0].id == "id"
 
+    def test_sync_workspaces_iterator(self, respx_mock):
+        coze = Coze(auth=TokenAuth(token="token"))
+
+        total = 10
+        for idx in range(total):
+            mock_get_workspace_list(respx_mock, total=total, page=idx + 1, idx=idx + 1)
+
+        total_result = 0
+        for idx, workspace in enumerate(coze.workspaces.list(page_size=1)):
+            total_result += 1
+            assert workspace
+            assert workspace.id == f"id_{idx + 1}"
+        assert total_result == total
+
+    def test_sync_workspaces_page_iterator(self, respx_mock):
+        coze = Coze(auth=TokenAuth(token="token"))
+
+        total = 10
+        size = 1
+        for idx in range(total):
+            mock_get_workspace_list(respx_mock, total=total, page=idx + 1, idx=idx + 1)
+
+        total_result = 0
+        for idx, page in enumerate(coze.workspaces.list(page_size=1).iter_pages()):
+            total_result += 1
+            assert page
+            assert page.total == total
+            assert len(page.items) == size
+            workspace = page.items[0]
+            assert workspace.id == f"id_{idx + 1}"
+        assert total_result == total
+
 
 @pytest.mark.respx(base_url="https://api.coze.com")
 @pytest.mark.asyncio
 class TestAsyncWorkspace:
-    async def test_list(self, respx_mock):
+    async def test_async_workspaces_list(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        respx_mock.get("/v1/workspaces").mock(
-            httpx.Response(
-                200,
-                json={
-                    "data": {
-                        "total_count": 1,
-                        "workspaces": [
-                            Workspace(
-                                id="id",
-                                name="name",
-                                icon_url="icon_url",
-                                role_type=WorkspaceRoleType.ADMIN,
-                                workspace_type=WorkspaceType.PERSONAL,
-                            ).model_dump()
-                        ],
-                    }
-                },
-            )
-        )
+        mock_get_workspace_list(respx_mock, total=1, page=1, idx=0)
 
-        res = await coze.workspaces.list()
+        res = await coze.workspaces.list(page_num=1)
 
         assert res
         assert res.items[0].id == "id"
+
+    async def test_async_workspaces_iterator(self, respx_mock):
+        coze = AsyncCoze(auth=TokenAuth(token="token"))
+
+        total = 10
+        for idx in range(total):
+            mock_get_workspace_list(respx_mock, total=total, page=idx + 1, idx=idx + 1)
+
+        total_result = 0
+        idx = 0
+        async for workspace in await coze.workspaces.list(page_size=1):
+            assert workspace
+            assert workspace.id == f"id_{idx + 1}"
+            idx += 1
+            total_result += 1
+        assert total_result == total
+
+    async def test_async_workspaces_page_iterator(self, respx_mock):
+        coze = AsyncCoze(auth=TokenAuth(token="token"))
+
+        total = 10
+        for idx in range(total):
+            mock_get_workspace_list(respx_mock, total=total, page=idx + 1, idx=idx + 1)
+
+        total_result = 0
+        idx = 0
+        resp = await coze.workspaces.list(page_size=1)
+        async for page in resp.iter_pages():
+            assert page
+            workspace = page.items[0]
+            assert workspace
+            assert workspace.id == f"id_{idx + 1}"
+            idx += 1
+            total_result += 1
+        assert total_result == total


### PR DESCRIPTION
- Added pagination iterator, support synchronous and asynchronous
- Enhanced paginator to support three usage methods:
  1. Use paginator as a regular object, accessing T list via items attribute
  2. Iterate over paginator to get T, ignoring pagination details and retrieving all data
  3. Iterate over iter_pages method to get the paginator itself (i.e., handle pagination)