### PR TITLE
fix: Handle errors for chat.failed scenarios

### DIFF
--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -26,6 +26,7 @@ from .bots import (
 )
 from .chat import (
     Chat,
+    ChatError,
     ChatEvent,
     ChatEventType,
     ChatStatus,
@@ -45,7 +46,7 @@ from .config import (
 )
 from .conversations import Conversation
 from .coze import AsyncCoze, Coze
-from .exception import CozeAPIError, CozeError, CozeEventError, CozePKCEAuthError, CozePKCEAuthErrorType
+from .exception import CozeAPIError, CozeError, CozeInvalidEventError, CozePKCEAuthError, CozePKCEAuthErrorType
 from .files import File
 from .knowledge.documents import (
     Document,
@@ -110,16 +111,17 @@ __all__ = [
     "Bot",
     "SimpleBot",
     # chat
+    "Chat",
+    "ChatError",
+    "ChatEvent",
+    "ChatEventType",
+    "ChatStatus",
+    "Message",
+    "MessageContentType",
+    "MessageObjectString",
+    "MessageObjectStringType",
     "MessageRole",
     "MessageType",
-    "MessageContentType",
-    "MessageObjectStringType",
-    "ChatStatus",
-    "ChatEventType",
-    "MessageObjectString",
-    "Message",
-    "Chat",
-    "ChatEvent",
     "ToolOutput",
     # conversations
     "Conversation",
@@ -160,7 +162,7 @@ __all__ = [
     # exception
     "CozeError",
     "CozeAPIError",
-    "CozeEventError",
+    "CozeInvalidEventError",
     "CozePKCEAuthError",
     "CozePKCEAuthErrorType",
     # model

--- a/cozepy/auth/__init__.py
+++ b/cozepy/auth/__init__.py
@@ -693,7 +693,6 @@ class TokenAuth(Auth):
     """
 
     def __init__(self, token: str):
-        # TODO: 其他 sdk 实现
         assert isinstance(token, str)
         assert len(token) > 0
         self._token = token

--- a/cozepy/exception.py
+++ b/cozepy/exception.py
@@ -11,10 +11,6 @@ class CozeError(Exception):
 
 
 class CozeAPIError(CozeError):
-    """
-    base class for all api errors
-    """
-
     def __init__(self, code: Optional[int] = None, msg: str = "", logid: Optional[str] = None):
         self.code = code
         self.msg = msg
@@ -36,21 +32,13 @@ COZE_PKCE_AUTH_ERROR_TYPE_ENUMS = set(e.value for e in CozePKCEAuthErrorType)
 
 
 class CozePKCEAuthError(CozeError):
-    """
-    base class for all pkce auth errors
-    """
-
     def __init__(self, error: CozePKCEAuthErrorType, logid: Optional[str] = None):
         super().__init__(f"pkce auth error: {error.value}")
         self.error = error
         self.logid = logid
 
 
-class CozeEventError(CozeError):
-    """
-    base class for all event errors
-    """
-
+class CozeInvalidEventError(CozeError):
     def __init__(self, field: str = "", data: str = "", logid: str = ""):
         self.field = field
         self.data = data

--- a/cozepy/workflows/runs/__init__.py
+++ b/cozepy/workflows/runs/__init__.py
@@ -99,7 +99,7 @@ class WorkflowEvent(CozeModel):
     error: Optional[WorkflowEventError] = None
 
 
-def _workflow_stream_handler(data: Dict[str, str], is_async: bool = False) -> WorkflowEvent:
+def _workflow_stream_handler(data: Dict[str, str], logid: str, is_async: bool = False) -> WorkflowEvent:
     id = int(data["id"])
     event = data["event"]
     event_data = data["data"]  # type: str
@@ -125,12 +125,12 @@ def _workflow_stream_handler(data: Dict[str, str], is_async: bool = False) -> Wo
         raise ValueError(f"invalid workflows.event: {event}, {event_data}")
 
 
-def _sync_workflow_stream_handler(data: Dict[str, str]) -> WorkflowEvent:
-    return _workflow_stream_handler(data, is_async=False)
+def _sync_workflow_stream_handler(data: Dict[str, str], logid: str) -> WorkflowEvent:
+    return _workflow_stream_handler(data, logid=logid, is_async=False)
 
 
-def _async_workflow_stream_handler(data: Dict[str, str]) -> WorkflowEvent:
-    return _workflow_stream_handler(data, is_async=True)
+def _async_workflow_stream_handler(data: Dict[str, str], logid: str) -> WorkflowEvent:
+    return _workflow_stream_handler(data, logid=logid, is_async=True)
 
 
 class WorkflowsRunsClient(object):

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,4 +1,4 @@
-from cozepy import CozeAPIError, CozeEventError, CozePKCEAuthError, CozePKCEAuthErrorType
+from cozepy import CozeAPIError, CozeInvalidEventError, CozePKCEAuthError, CozePKCEAuthErrorType
 
 
 def test_coze_error():
@@ -17,8 +17,8 @@ def test_coze_error():
     err = CozePKCEAuthError(CozePKCEAuthErrorType.AUTHORIZATION_PENDING)
     assert err.error == "authorization_pending"
 
-    err = CozeEventError("event", "xxx", "logid")
+    err = CozeInvalidEventError("event", "xxx", "logid")
     assert str(err) == "invalid event, field: event, data: xxx, logid: logid"
 
-    err = CozeEventError("", "xxx", "logid")
+    err = CozeInvalidEventError("", "xxx", "logid")
     assert str(err) == "invalid event, data: xxx, logid: logid"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 import pytest
 
-from cozepy import CozeEventError, Stream
+from cozepy import CozeInvalidEventError, Stream
 from cozepy.model import AsyncStream
 from cozepy.util import anext
 
@@ -22,14 +22,16 @@ class TestStream:
         items = ["event:x"]
         s = Stream(iter(items), ["field"], mock_sync_handler, "mocked-logid")
 
-        with pytest.raises(CozeEventError, match="invalid event, data: event:x, logid: mocked-logid"):
+        with pytest.raises(CozeInvalidEventError, match="invalid event, data: event:x, logid: mocked-logid"):
             next(s)
 
     def test_stream_invalid_field(self):
         items = ["event:x1", "event:x2"]
         s = Stream(iter(items), ["event", "second"], mock_sync_handler, "mocked-logid")
 
-        with pytest.raises(CozeEventError, match="invalid event, field: event, data: event:x2, logid: mocked-logid"):
+        with pytest.raises(
+            CozeInvalidEventError, match="invalid event, field: event, data: event:x2, logid: mocked-logid"
+        ):
             next(s)
 
 
@@ -39,12 +41,14 @@ class TestAsyncStream:
         items = ["event:x"]
         s = AsyncStream(to_async_iterator(items), ["field"], mock_async_handler, "mocked-logid")
 
-        with pytest.raises(CozeEventError, match="invalid event, data: event:x, logid: mocked-logid"):
+        with pytest.raises(CozeInvalidEventError, match="invalid event, data: event:x, logid: mocked-logid"):
             await anext(s)
 
     async def test_stream_invalid_field(self):
         items = ["event:x1", "event:x2"]
         s = AsyncStream(to_async_iterator(items), ["event", "second"], mock_async_handler, "mocked-logid")
 
-        with pytest.raises(CozeEventError, match="invalid event, field: event, data: event:x2, logid: mocked-logid"):
+        with pytest.raises(
+            CozeInvalidEventError, match="invalid event, field: event, data: event:x2, logid: mocked-logid"
+        ):
             await anext(s)


### PR DESCRIPTION
- Implemented error handling for cases when `conversation.chat.failed` occurs
- Added ChatError to parse error messages
- Threw `CozeAPIError` exception when `conversation.chat.failed` is encountered
- Rename `CozeEventError` to `CozeInvalidEventError`