### PR TITLE
refactor: Change upload file parameter from str to Union[Path]

### DIFF
--- a/cozepy/files/__init__.py
+++ b/cozepy/files/__init__.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Union
+
 from cozepy.auth import Auth
 from cozepy.model import CozeModel
 from cozepy.request import Requester
@@ -27,7 +30,7 @@ class FilesClient(object):
         self._auth = auth
         self._requester = requester
 
-    def upload(self, *, file: str) -> File:
+    def upload(self, *, file: Union[Path]) -> File:
         """
         Upload files to Coze platform.
 
@@ -71,7 +74,7 @@ class AsyncFilesClient(object):
         self._auth = auth
         self._requester = requester
 
-    async def upload(self, *, file: str) -> File:
+    async def upload(self, *, file: Union[Path]) -> File:
         """
         Upload files to Coze platform.
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import httpx
@@ -8,15 +9,15 @@ from cozepy import AsyncCoze, Coze, File, TokenAuth
 
 @pytest.mark.respx(base_url="https://api.coze.com")
 class TestFile:
-    def test_file_create(self, respx_mock):
+    def test_sync_file_upload(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        with patch("builtins.open", mock_open(read_data="data")):
-            respx_mock.post("/v1/files/upload").mock(
-                httpx.Response(200, json={"data": File(id="1", bytes=2, created_at=3, file_name="name").model_dump()})
-            )
+        respx_mock.post("/v1/files/upload").mock(
+            httpx.Response(200, json={"data": File(id="1", bytes=2, created_at=3, file_name="name").model_dump()})
+        )
 
-            file = coze.files.upload(file="/path")
+        with patch("builtins.open", mock_open(read_data="data")):
+            file = coze.files.upload(file=Path("/path"))
             assert file
             assert "name" == file.file_name
 
@@ -35,7 +36,7 @@ class TestFile:
 @pytest.mark.respx(base_url="https://api.coze.com")
 @pytest.mark.asyncio
 class TestAsyncFile:
-    async def test_create(self, respx_mock):
+    async def test_async_file_upload(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         with patch("builtins.open", mock_open(read_data="data")):
@@ -43,11 +44,11 @@ class TestAsyncFile:
                 httpx.Response(200, json={"data": File(id="1", bytes=2, created_at=3, file_name="name").model_dump()})
             )
 
-            file = await coze.files.upload(file="/path")
+            file = await coze.files.upload(file=Path("/path"))
             assert file
             assert "name" == file.file_name
 
-    async def test_retrieve(self, respx_mock):
+    async def test_async_file_retrieve(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         respx_mock.get("/v1/files/retrieve").mock(


### PR DESCRIPTION
- Modified upload file parameter type from str to Union[Path]
- Improved flexibility and usability of the upload function