### PR TITLE
refactor: Standardize and enhance various components

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,20 @@ chat = coze.chat.create(
     bot_id='bot id',
     user_id='user id',
     additional_messages=[
-        Message.user_text_message('how are you?'),
-        Message.assistant_text_message('I am fine, thank you.')
+        Message.build_user_question_text('how are you?'),
     ],
 )
 start = int(time.time())
 while chat.status == ChatStatus.IN_PROGRESS:
     if int(time.time()) - start > 120:
         # too long, cancel chat
-        coze.chat.cancel(conversation_id=chat.conversation_id, chat_id=chat.chat_id)
+        coze.chat.cancel(conversation_id=chat.conversation_id, chat_id=chat.id)
         break
 
     time.sleep(1)
-    chat = coze.chat.retrieve(conversation_id=chat.conversation_id, chat_id=chat.chat_id)
+    chat = coze.chat.retrieve(conversation_id=chat.conversation_id, chat_id=chat.id)
 
-message_list = coze.chat.messages.list(conversation_id=chat.conversation_id, chat_id=chat.chat_id)
+message_list = coze.chat.messages.list(conversation_id=chat.conversation_id, chat_id=chat.id)
 for message in message_list:
     print('got message:', message.content)
 
@@ -85,8 +84,8 @@ stream = coze.chat.stream(
     bot_id='bot id',
     user_id='user id',
     additional_messages=[
-        Message.user_text_message('how are you?'),
-        Message.assistant_text_message('I am fine, thank you.')
+        Message.build_user_question_text('how are you?'),
+        Message.build_assistant_answer('I am fine, thank you.')
     ],
 )
 for event in stream:
@@ -136,8 +135,8 @@ coze = Coze(auth=TokenAuth("your_token"))
 # create conversation
 conversation = coze.conversations.create(
     messages=[
-        Message.user_text_message('how are you?'),
-        Message.assistant_text_message('I am fine, thank you.')
+        Message.build_user_question_text('how are you?'),
+        Message.build_assistant_answer('I am fine, thank you.')
     ],
 )
 
@@ -236,7 +235,7 @@ documents = coze.knowledge.documents.create(
     document_bases=[
         DocumentBase(
             name='document name',
-            source_info=DocumentSourceInfo.from_local_file('local file content')
+            source_info=DocumentSourceInfo.build_local_file('local file content')
         )
     ],
     chunk_strategy=DocumentChunkStrategy.auto()
@@ -248,7 +247,7 @@ documents = coze.knowledge.documents.create(
     document_bases=[
         DocumentBase(
             name='document name',
-            source_info=DocumentSourceInfo.from_web_page('https://example.com')
+            source_info=DocumentSourceInfo.build_web_page('https://example.com')
         )
     ],
     chunk_strategy=DocumentChunkStrategy.auto()
@@ -394,8 +393,8 @@ async def main() -> None:
         bot_id='bot id',
         user_id='user id',
         additional_messages=[
-            Message.user_text_message('how are you?'),
-            Message.assistant_text_message('I am fine, thank you.')
+            Message.build_user_question_text('how are you?'),
+            Message.build_assistant_answer('I am fine, thank you.')
         ],
     )
     print('chat', chat)
@@ -419,8 +418,8 @@ stream = coze.chat.stream(
     bot_id='bot id',
     user_id='user id',
     additional_messages=[
-        Message.user_text_message('how are you?'),
-        Message.assistant_text_message('I am fine, thank you.')
+        Message.build_user_question_text('how are you?'),
+        Message.build_assistant_answer('I am fine, thank you.')
     ],
 )
 for event in stream:
@@ -474,8 +473,8 @@ async def main():
         bot_id='bot id',
         user_id='user id',
         additional_messages=[
-            Message.user_text_message('how are you?'),
-            Message.assistant_text_message('I am fine, thank you.')
+            Message.build_user_question_text('how are you?'),
+            Message.build_assistant_answer('I am fine, thank you.')
         ],
     )
     async for event in stream:

--- a/cozepy/auth/__init__.py
+++ b/cozepy/auth/__init__.py
@@ -55,7 +55,7 @@ class Scope(CozeModel):
     attribute_constraint: Optional[ScopeAttributeConstraint] = None
 
     @staticmethod
-    def from_bot_chat(bot_id_list: List[str], permission_list: Optional[List[str]] = None) -> "Scope":
+    def build_bot_chat(bot_id_list: List[str], permission_list: Optional[List[str]] = None) -> "Scope":
         if not permission_list:
             permission_list = ["Connector.botChat"]
         return Scope(
@@ -79,9 +79,9 @@ class OAuthApp(object):
     def _get_oauth_url(
         self,
         redirect_uri: str,
-        state: str,
         code_challenge: Optional[str] = None,
         code_challenge_method: Optional[str] = None,
+        state: str = "",
         workspace_id: Optional[str] = None,
     ):
         params = {
@@ -150,7 +150,7 @@ class WebOAuthApp(OAuthApp):
     def get_oauth_url(
         self,
         redirect_uri: str,
-        state: str,
+        state: str = "",
         workspace_id: Optional[str] = None,
     ):
         """
@@ -165,7 +165,7 @@ class WebOAuthApp(OAuthApp):
         """
         return self._get_oauth_url(
             redirect_uri,
-            state,
+            state=state,
             workspace_id=workspace_id,
         )
 
@@ -212,7 +212,7 @@ class AsyncWebOAuthApp(OAuthApp):
     def get_oauth_url(
         self,
         redirect_uri: str,
-        state: str,
+        state: str = "",
         workspace_id: Optional[str] = None,
     ):
         """
@@ -227,7 +227,7 @@ class AsyncWebOAuthApp(OAuthApp):
         """
         return self._get_oauth_url(
             redirect_uri,
-            state,
+            state=state,
             workspace_id=workspace_id,
         )
 
@@ -273,9 +273,14 @@ class JWTOAuthApp(OAuthApp):
         self._public_key_id = public_key_id
         super().__init__(client_id, base_url, www_base_url="")
 
-    def get_access_token(self, ttl: int, scope: Optional[Scope] = None) -> OAuthToken:
+    def get_access_token(self, ttl: int = 900, scope: Optional[Scope] = None) -> OAuthToken:
         """
         Get the token by jwt with jwt auth flow.
+
+        :param ttl: The validity period of the AccessToken you apply for is in seconds.
+        The default value is 900 seconds and the maximum value you can set is 86399 seconds,
+        which is 24 hours.
+        :param scope:
         """
         jwt_token = self._gen_jwt(3600)
         url = f"{self._base_url}/api/permission/oauth2/token"
@@ -366,9 +371,9 @@ class PKCEOAuthApp(OAuthApp):
     def get_oauth_url(
         self,
         redirect_uri: str,
-        state: str,
         code_verifier: str,
         code_challenge_method: Literal["plain", "S256"] = "plain",
+        state: str = "",
         workspace_id: Optional[str] = None,
     ):
         """
@@ -376,10 +381,10 @@ class PKCEOAuthApp(OAuthApp):
 
         :param redirect_uri: The redirect_uri of your app, where authentication responses can be sent and received by
         your app. It must exactly match one of the redirect URIs you registered in the OAuth Apps.
-        :param state: A value included in the request that is also returned in the token response. It can be a string
-        of any hash value.
         :param code_verifier:
         :param code_challenge_method:
+        :param state: A value included in the request that is also returned in the token response. It can be a string
+        of any hash value.
         :param workspace_id:
         :return:
         """
@@ -387,9 +392,9 @@ class PKCEOAuthApp(OAuthApp):
 
         return self._get_oauth_url(
             redirect_uri,
-            state,
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
+            state=state,
             workspace_id=workspace_id,
         )
 
@@ -433,9 +438,9 @@ class AsyncPKCEOAuthApp(OAuthApp):
     def get_oauth_url(
         self,
         redirect_uri: str,
-        state: str,
         code_verifier: str,
         code_challenge_method: Literal["plain", "S256"] = "plain",
+        state: str = "",
         workspace_id: Optional[str] = None,
     ):
         """
@@ -443,10 +448,10 @@ class AsyncPKCEOAuthApp(OAuthApp):
 
         :param redirect_uri: The redirect_uri of your app, where authentication responses can be sent and received by
         your app. It must exactly match one of the redirect URIs you registered in the OAuth Apps.
-        :param state: A value included in the request that is also returned in the token response. It can be a string
-        of any hash value.
         :param code_verifier:
         :param code_challenge_method:
+        :param state: A value included in the request that is also returned in the token response. It can be a string
+        of any hash value.
         :param workspace_id:
         :return:
         """
@@ -454,9 +459,9 @@ class AsyncPKCEOAuthApp(OAuthApp):
 
         return self._get_oauth_url(
             redirect_uri,
-            state,
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
+            state=state,
             workspace_id=workspace_id,
         )
 

--- a/cozepy/files/__init__.py
+++ b/cozepy/files/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from cozepy.auth import Auth
 from cozepy.model import CozeModel
@@ -13,15 +13,15 @@ class File(CozeModel):
 
     # The total byte size of the file.
     # 文件的总字节数。
-    bytes: int
+    bytes: Optional[int] = None
 
     # The upload time of the file, in the format of a 10-digit Unix timestamp in seconds (s).
     # 文件的上传时间，格式为 10 位的 Unixtime 时间戳，单位为秒（s）。
-    created_at: int
+    created_at: Optional[int] = None
 
     # The name of the file.
     # 文件名称。
-    file_name: str
+    file_name: Optional[str] = None
 
 
 class FilesClient(object):

--- a/cozepy/knowledge/documents/__init__.py
+++ b/cozepy/knowledge/documents/__init__.py
@@ -215,11 +215,11 @@ class DocumentSourceInfo(CozeModel):
     document_source: Optional[int] = None
 
     @staticmethod
-    def from_local_file(content: str, file_type: str = "txt") -> "DocumentSourceInfo":
+    def build_local_file(content: str, file_type: str = "txt") -> "DocumentSourceInfo":
         return DocumentSourceInfo(file_base64=base64_encode_string(content), file_type=file_type)
 
     @staticmethod
-    def from_web_page(url: str) -> "DocumentSourceInfo":
+    def build_web_page(url: str) -> "DocumentSourceInfo":
         return DocumentSourceInfo(web_url=url, document_source=1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ line-length = 120
 select = ["E", "F", "I"]
 ignore = ["E501"]
 
+[tool.mypy]
+exclude = [
+    "examples/",
+    "tests/"
+]
+
 [tool.coverage.report]
 precision = 1
 skip_covered = true

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -199,7 +199,7 @@ class TestJWTOAuthApp:
             )
         )
 
-        token = app.get_access_token(100, scope=Scope.from_bot_chat(["bot id"]))
+        token = app.get_access_token(100, scope=Scope.build_bot_chat(["bot id"]))
         assert token.access_token == mock_token
 
 
@@ -216,7 +216,7 @@ class TestAsyncJWTOAuthApp:
             )
         )
 
-        token = await app.get_access_token(100, scope=Scope.from_bot_chat(["bot id"]))
+        token = await app.get_access_token(100, scope=Scope.build_bot_chat(["bot id"]))
         assert token.access_token == mock_token
 
 
@@ -225,7 +225,7 @@ class TestPKCEOAuthApp:
     def test_get_oauth_url(self, respx_mock):
         app = PKCEOAuthApp("client id")
 
-        url = app.get_oauth_url("https://example.com", "state", "code_verifier", "S256")
+        url = app.get_oauth_url("https://example.com", "code_verifier", "S256", state="state")
         assert (
             "https://www.coze.com/api/permission/oauth2/authorize?"
             "response_type=code&client_id=client+id&"
@@ -233,7 +233,9 @@ class TestPKCEOAuthApp:
             "code_challenge=73oehA2tBul5grZPhXUGQwNAjxh69zNES8bu2bVD0EM&code_challenge_method=S256"
         ) == url
 
-        url = app.get_oauth_url("https://example.com", "state", "code_verifier", "S256", workspace_id="this_is_id")
+        url = app.get_oauth_url(
+            "https://example.com", "code_verifier", "S256", state="state", workspace_id="this_is_id"
+        )
         assert (
             "https://www.coze.com/api/permission/oauth2/workspace_id/this_is_id/authorize?"
             "response_type=code&client_id=client+id&"
@@ -274,7 +276,7 @@ class TestAsyncPKCEOAuthApp:
     async def test_get_oauth_url(self, respx_mock):
         app = AsyncPKCEOAuthApp("client id")
 
-        url = app.get_oauth_url("https://example.com", "state", "code_verifier", "S256")
+        url = app.get_oauth_url("https://example.com", "code_verifier", "S256", state="state")
         assert (
             "https://www.coze.com/api/permission/oauth2/authorize?"
             "response_type=code&client_id=client+id&"
@@ -282,7 +284,9 @@ class TestAsyncPKCEOAuthApp:
             "code_challenge=73oehA2tBul5grZPhXUGQwNAjxh69zNES8bu2bVD0EM&code_challenge_method=S256"
         ) == url
 
-        url = app.get_oauth_url("https://example.com", "state", "code_verifier", "S256", workspace_id="this_is_id")
+        url = app.get_oauth_url(
+            "https://example.com", "code_verifier", "S256", workspace_id="this_is_id", state="state"
+        )
         assert (
             "https://www.coze.com/api/permission/oauth2/workspace_id/this_is_id/authorize?"
             "response_type=code&client_id=client+id&"

--- a/tests/test_chat_message.py
+++ b/tests/test_chat_message.py
@@ -9,8 +9,8 @@ class TestChatMessage:
     def test_create(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
-        msg2 = Message.user_text_message("hey")
+        msg = Message.build_user_question_text("hi")
+        msg2 = Message.build_user_question_text("hey")
         respx_mock.post("/v3/chat/message/list").mock(
             httpx.Response(
                 200,
@@ -29,8 +29,8 @@ class TestAsyncChatMessage:
     async def test_chat_message_list(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
-        msg2 = Message.user_text_message("hey")
+        msg = Message.build_user_question_text("hi")
+        msg2 = Message.build_user_question_text("hey")
         respx_mock.post("/v3/chat/message/list").mock(
             httpx.Response(
                 200,

--- a/tests/test_conversation_message.py
+++ b/tests/test_conversation_message.py
@@ -21,7 +21,7 @@ def mock_conversations_messages_list(respx_mock, has_more, last_id):
                 "first_id": "",
                 "has_more": has_more,
                 "last_id": f"{last_id + 1}",
-                "data": [Message.user_text_message(f"id_{last_id}").model_dump()],
+                "data": [Message.build_user_question_text(f"id_{last_id}").model_dump()],
             },
         )
     )
@@ -32,7 +32,7 @@ class TestConversationMessage:
     def test_sync_conversations_messages_create(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        msg = Message.assistant_text_message("hi")
+        msg = Message.build_assistant_answer("hi")
         respx_mock.post("/v1/conversation/message/create").mock(httpx.Response(200, json={"data": msg.model_dump()}))
 
         message = coze.conversations.messages.create(
@@ -87,7 +87,7 @@ class TestConversationMessage:
     def test_sync_conversations_messages_retrieve(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.get("/v1/conversation/message/retrieve").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = coze.conversations.messages.retrieve(conversation_id="conversation id", message_id="message id")
@@ -97,7 +97,7 @@ class TestConversationMessage:
     def test_sync_conversations_messages_update(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.post("/v1/conversation/message/modify").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = coze.conversations.messages.update(conversation_id="conversation id", message_id="message id")
@@ -107,7 +107,7 @@ class TestConversationMessage:
     def test_sync_conversations_messages_delete(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.post("/v1/conversation/message/delete").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = coze.conversations.messages.delete(conversation_id="conversation id", message_id="message id")
@@ -121,7 +121,7 @@ class TestAsyncConversationMessage:
     async def test_async_conversations_messages_create(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        msg = Message.assistant_text_message("hi")
+        msg = Message.build_assistant_answer("hi")
         respx_mock.post("/v1/conversation/message/create").mock(httpx.Response(200, json={"data": msg.model_dump()}))
 
         message = await coze.conversations.messages.create(
@@ -176,7 +176,7 @@ class TestAsyncConversationMessage:
     async def test_async_conversations_messages_retrieve(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.get("/v1/conversation/message/retrieve").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = await coze.conversations.messages.retrieve(conversation_id="conversation id", message_id="message id")
@@ -186,7 +186,7 @@ class TestAsyncConversationMessage:
     async def test_async_conversations_messages_update(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.post("/v1/conversation/message/modify").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = await coze.conversations.messages.update(conversation_id="conversation id", message_id="message id")
@@ -196,7 +196,7 @@ class TestAsyncConversationMessage:
     async def test_async_conversations_messages_delete(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        msg = Message.user_text_message("hi")
+        msg = Message.build_user_question_text("hi")
         respx_mock.post("/v1/conversation/message/delete").mock(httpx.Response(200, json=msg.model_dump()))
 
         message = await coze.conversations.messages.delete(conversation_id="conversation id", message_id="message id")

--- a/tests/test_knowledge_documents.py
+++ b/tests/test_knowledge_documents.py
@@ -76,7 +76,7 @@ class TestKnowledgeDocuments:
             document_bases=[
                 DocumentBase(
                     name="name",
-                    source_info=DocumentSourceInfo.from_web_page("x"),
+                    source_info=DocumentSourceInfo.build_web_page("x"),
                     update_rule=DocumentUpdateRule.auto_update(1),
                 ),
             ],
@@ -100,7 +100,7 @@ class TestKnowledgeDocuments:
             document_bases=[
                 DocumentBase(
                     name="name",
-                    source_info=DocumentSourceInfo.from_local_file("content"),
+                    source_info=DocumentSourceInfo.build_local_file("content"),
                     update_rule=DocumentUpdateRule.no_auto_update(),
                 ),
             ],
@@ -228,7 +228,7 @@ class TestAsyncKnowledgeDocuments:
             document_bases=[
                 DocumentBase(
                     name="name",
-                    source_info=DocumentSourceInfo.from_web_page("x"),
+                    source_info=DocumentSourceInfo.build_web_page("x"),
                     update_rule=DocumentUpdateRule.auto_update(1),
                 ),
             ],
@@ -252,7 +252,7 @@ class TestAsyncKnowledgeDocuments:
             document_bases=[
                 DocumentBase(
                     name="name",
-                    source_info=DocumentSourceInfo.from_local_file("content"),
+                    source_info=DocumentSourceInfo.build_local_file("content"),
                     update_rule=DocumentUpdateRule.no_auto_update(),
                 ),
             ],


### PR DESCRIPTION
- Renamed class static methods to consistently start with build
- Set default expiration time of 900s for jwt oauth token
- Added default empty string value for state parameter in `OAuthApp`
- Modified some fields in `CozeModel` to be optional
- Added `create_and_poll` method to encapsulate chat.create and chat.retrieve