### PR TITLE
fix: Fix `build_user_question_objects` method in Message

### DIFF
--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -154,7 +154,7 @@ class Message(CozeModel):
             role=MessageRole.USER,
             type=MessageType.QUESTION,
             content=json.dumps([obj.model_dump() for obj in objects]),
-            content_type=MessageContentType.TEXT,
+            content_type=MessageContentType.OBJECT_STRING,
             meta_data=meta_data,
         )
 


### PR DESCRIPTION
- Fixed `build_user_question_objects` method to change content_type from `text` to `object_string`
- Related Issue: https://github.com/coze-dev/coze-py/issues/84