### PR TITLE
fix: Resolve httpx.ResponseNotRead error in stream mode

### DIFF
--- a/cozepy/request.py
+++ b/cozepy/request.py
@@ -379,6 +379,7 @@ class Requester(object):
         self, method: str, url: str, response: Response, data_field: str = "data"
     ) -> Tuple[Optional[int], str, Any]:
         try:
+            response.read()
             body = response.json()
             logid = response.headers.get("x-tt-logid")
             log_debug("request %s#%s responding, logid=%s, data=%s", method, url, logid, body)


### PR DESCRIPTION
- Fixed issue with `response.json` raising `httpx.ResponseNotRead` in stream mode
- Non-stream mode defaults to `response.read` as expected
- Stream mode with correct response uses `iter_lines` without issues
- Stream mode with errors (e.g., token errors) now handled properly