### PR TITLE
fix: Fix field name in ChatToolCallFunction from 'argument' to 'arguments'

### DIFF
--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -210,7 +210,7 @@ class ChatToolCallFunction(CozeModel):
     name: str
 
     # The parameters of the method.
-    argument: str
+    arguments: str
 
 
 class ChatToolCall(CozeModel):


### PR DESCRIPTION
- Updated field name from 'argument' to 'arguments' in `ChatToolCallFunction`