### PR TITLE
feat: Add conversation management APIs

### DIFF
--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -55,7 +55,7 @@ from .config import (
     DEFAULT_CONNECTION_LIMITS,
     DEFAULT_TIMEOUT,
 )
-from .conversations import Conversation
+from .conversations import Conversation, Section
 from .coze import AsyncCoze, Coze
 from .exception import CozeAPIError, CozeError, CozeInvalidEventError, CozePKCEAuthError, CozePKCEAuthErrorType
 from .files import File
@@ -151,6 +151,7 @@ __all__ = [
     "ToolOutput",
     # conversations
     "Conversation",
+    "Section",
     # files
     "File",
     # knowledge.documents

--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -207,6 +207,9 @@ class ChatStatus(str, Enum):
     # The session is interrupted and requires further processing.
     REQUIRES_ACTION = "requires_action"
 
+    # The session is canceled.
+    CANCELED = "canceled"
+
 
 class ChatError(CozeModel):
     # The error code. An integer type. 0 indicates success, other values indicate failure.

--- a/cozepy/conversations/__init__.py
+++ b/cozepy/conversations/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from cozepy.auth import Auth
 from cozepy.chat import Message
@@ -62,7 +62,7 @@ class ConversationsClient(object):
         :return: Conversation object
         """
         url = f"{self._base_url}/v1/conversation/create"
-        body = {
+        body: Dict[str, Any] = {
             "messages": [i.model_dump() for i in messages] if messages and len(messages) > 0 else [],
             "meta_data": meta_data,
         }
@@ -157,7 +157,7 @@ class AsyncConversationsClient(object):
         :return: Conversation object
         """
         url = f"{self._base_url}/v1/conversation/create"
-        body = {
+        body: Dict[str, Any] = {
             "messages": [i.model_dump() for i in messages] if messages and len(messages) > 0 else [],
             "meta_data": meta_data,
         }

--- a/cozepy/model.py
+++ b/cozepy/model.py
@@ -210,10 +210,11 @@ class NumberPaged(PagedBase[T]):
     def _is_page_has_more(page: "NumberPaged[T]") -> bool:
         if page._has_more is not None:
             return page._has_more
+        if page._total is not None:
+            return page._total > page.page_num * page.page_size
         if page._items is not None and page._items and len(page._items) >= page.page_size:
             return True
-        if page.total is not None and page.total > page.page_num * page.page_size:
-            return True
+
         return False
 
 
@@ -285,9 +286,9 @@ class AsyncNumberPaged(AsyncPagedBase[T]):
     def _is_page_has_more(page: "AsyncNumberPaged[T]") -> bool:
         if page._has_more is not None:
             return page._has_more
-        if page._items is not None and page._items and len(page._items) >= page.page_size:
-            return True
-        if page.total is not None and page.total > page.page_num * page.page_size:
+        if page._total is not None:
+            return page._total > page.page_num * page.page_size
+        if page._total is not None and page._items and len(page._items) >= page.page_size:
             return True
         return False
 

--- a/examples/conversation_list.py
+++ b/examples/conversation_list.py
@@ -1,5 +1,5 @@
 """
-This example is about how to create conversation and retrieve.
+This example is about how to list conversation.
 """
 
 import logging
@@ -22,6 +22,8 @@ coze_api_token = os.getenv("COZE_API_TOKEN")
 # The default access is api.coze.com, but if you need to access api.coze.cn,
 # please use base_url to configure the api endpoint to access
 coze_api_base = os.getenv("COZE_API_BASE") or COZE_COM_BASE_URL
+# coze bot id
+coze_bot_id = os.getenv("COZE_BOT_ID") or "input your bot id"
 # Whether to print detailed logs
 is_debug = os.getenv("DEBUG")
 
@@ -31,20 +33,13 @@ if is_debug:
 # Init the Coze client through the access_token.
 coze = Coze(auth=TokenAuth(token=coze_api_token), base_url=coze_api_base)
 
-conversation = coze.conversations.create()
-print("Create conversation: ", conversation)
+conversations = coze.conversations.list(bot_id=coze_bot_id, page_size=2)
 
-conversation_retrieve = coze.conversations.retrieve(conversation_id=conversation.id)
-print("Retrieve conversation:", conversation_retrieve)
+for conversation in conversations:
+    print("conversation[id]", conversation.id)
+    print("conversation[created_at]", conversation.created_at)
+    print("conversation[last_section_id]", conversation.last_section_id)
+    print("")
 
-message = coze.conversations.messages.create(
-    conversation_id=conversation.id,
-    role=MessageRole.USER,
-    content="hi",
-    content_type=MessageContentType.TEXT,
-)
-
-print("Append message to conversation:", message)
-
-section = coze.conversations.clear(conversation_id=conversation.id)
-print("Clear conversation:", section)
+for page in conversations.iter_pages():
+    print("items", page.items)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -199,7 +199,7 @@ class TestJWTOAuthApp:
             )
         )
 
-        token = app.get_access_token(100, scope=Scope.build_bot_chat(["bot id"]))
+        token = app.get_access_token(100, scope=Scope.build_bot_chat(["bot id"]), session_name="session_name")
         assert token.access_token == mock_token
 
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -11,20 +11,77 @@ def make_conversation():
     return Conversation(id=random_hex(10), created_at=int(time.time()), meta_data={}, last_section_id=random_hex(10))
 
 
+def mock_list_conversation(respx_mock, has_more, page):
+    respx_mock.get(
+        "https://api.coze.com/v1/conversations",
+        params={
+            "page_num": page,
+        },
+    ).mock(
+        httpx.Response(
+            200,
+            headers={"x-tt-logid": "logid"},
+            json={
+                "data": {
+                    "conversations": [
+                        Conversation(
+                            id=f"id_{page}", created_at=int(time.time()), meta_data={}, last_section_id=random_hex(10)
+                        ).model_dump()
+                    ],
+                    "has_more": has_more,
+                }
+            },
+        )
+    )
+
+
 @pytest.mark.respx(base_url="https://api.coze.com")
 class TestConversation:
-    def test_create(self, respx_mock):
+    def test_sync_conversations_create(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         conversation = make_conversation()
+        bot_id = random_hex(10)
         respx_mock.post("/v1/conversation/create").mock(httpx.Response(200, json={"data": conversation.model_dump()}))
 
-        res = coze.conversations.create()
+        res = coze.conversations.create(bot_id=bot_id)
         assert res
         assert res.id == conversation.id
         assert res.last_section_id == conversation.last_section_id
 
-    def test_conversations_retrieve(self, respx_mock):
+    def test_sync_conversations_list(self, respx_mock):
+        coze = Coze(auth=TokenAuth(token="token"))
+
+        total = 10
+        size = 1
+        for idx in range(total):
+            mock_list_conversation(respx_mock, has_more=idx + 1 < total, page=idx + 1)
+
+        # no iter
+        resp = coze.conversations.list(bot_id="bot id", page_size=1)
+        assert resp
+        assert resp.has_more is True
+
+        # iter conversation
+        total_result = 0
+        for idx, conversation in enumerate(coze.conversations.list(bot_id="bot id", page_size=1)):
+            total_result += 1
+            assert conversation
+            assert conversation.id == f"id_{idx + 1}"
+        assert total_result == total
+
+        # iter page
+        total_result = 0
+        for idx, page in enumerate(coze.conversations.list(bot_id="bot id", page_size=1).iter_pages()):
+            total_result += 1
+            assert page
+            assert page.has_more == (idx + 1 < total)
+            assert len(page.items) == size
+            conversation = page.items[0]
+            assert conversation.id == f"id_{idx + 1}"
+        assert total_result == total
+
+    def test_sync_conversations_retrieve(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
         conversation = make_conversation()
@@ -39,18 +96,53 @@ class TestConversation:
 @pytest.mark.respx(base_url="https://api.coze.com")
 @pytest.mark.asyncio
 class TestAsyncConversation:
-    async def test_conversation_create(self, respx_mock):
+    async def test_async_conversation_create(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         conversation = make_conversation()
+        bot_id = random_hex(10)
         respx_mock.post("/v1/conversation/create").mock(httpx.Response(200, json={"data": conversation.model_dump()}))
 
-        res = await coze.conversations.create()
+        res = await coze.conversations.create(bot_id=bot_id)
         assert res
         assert res.id == conversation.id
         assert res.last_section_id == conversation.last_section_id
 
-    async def test_retrieve(self, respx_mock):
+    async def test_async_conversations_list(self, respx_mock):
+        coze = AsyncCoze(auth=TokenAuth(token="token"))
+
+        total = 10
+        size = 1
+        for idx in range(total):
+            mock_list_conversation(respx_mock, has_more=idx + 1 < total, page=idx + 1)
+
+        # no iter
+        resp = await coze.conversations.list(bot_id="bot id", page_size=1)
+        assert resp
+        assert resp.has_more is True
+
+        # iter conversation
+        total_result = 0
+        resp = await coze.conversations.list(bot_id="bot id", page_size=1)
+        for idx, conversation in enumerate([bot async for bot in resp]):
+            total_result += 1
+            assert conversation
+            assert conversation.id == f"id_{idx + 1}"
+        assert total_result == total
+
+        # iter page
+        total_result = 0
+        resp = await coze.conversations.list(bot_id="bot id", page_size=1)
+        for idx, page in enumerate([page async for page in resp.iter_pages()]):
+            total_result += 1
+            assert page
+            assert page.has_more == (idx + 1 < total)
+            assert len(page.items) == size
+            conversation = page.items[0]
+            assert conversation.id == f"id_{idx + 1}"
+        assert total_result == total
+
+    async def test_async_conversations_retrieve(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         conversation = make_conversation()


### PR DESCRIPTION
- Supported binding bot_id when creating a conversation
- Added get the list of conversations bound to bot_id
- Added clear a conversation and returned a new section
- Added bind session_name during JWT token creation