### PR TITLE
fix: Correct conversation_id parameter placement in chat API

### DIFF
--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -890,6 +890,7 @@ class AsyncChatClient(object):
                 url,
                 False,
                 Chat,
+                params=params,
                 body=body,
             )
 
@@ -898,6 +899,7 @@ class AsyncChatClient(object):
             url,
             True,
             None,
+            params=params,
             body=body,
         )
         return AsyncStream(resp.data, fields=["event", "data"], handler=_async_chat_stream_handler, logid=resp.logid)

--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -872,6 +872,9 @@ class AsyncChatClient(object):
         Conversation is an interaction between a bot and a user, including one or more messages.
         """
         url = f"{self._base_url}/v3/chat"
+        params = {
+            "conversation_id": conversation_id if conversation_id else None,
+        }
         body = {
             "bot_id": bot_id,
             "user_id": user_id,
@@ -879,7 +882,6 @@ class AsyncChatClient(object):
             "stream": stream,
             "custom_variables": custom_variables,
             "auto_save_history": auto_save_history,
-            "conversation_id": conversation_id if conversation_id else None,
             "meta_data": meta_data,
         }
         if not stream:


### PR DESCRIPTION
- Move conversation_id from request body to query parameters