### PR TITLE
fix: Update chat.cancel API to use body instead of params

### DIFF
--- a/cozepy/chat/__init__.py
+++ b/cozepy/chat/__init__.py
@@ -724,11 +724,11 @@ class ChatClient(object):
         :return:
         """
         url = f"{self._base_url}/v3/chat/cancel"
-        params = {
+        body = {
             "conversation_id": conversation_id,
             "chat_id": chat_id,
         }
-        return self._requester.request("post", url, False, Chat, params=params)
+        return self._requester.request("post", url, False, Chat, body=body)
 
     @property
     def messages(
@@ -1026,11 +1026,11 @@ class AsyncChatClient(object):
         :return:
         """
         url = f"{self._base_url}/v3/chat/cancel"
-        params = {
+        body = {
             "conversation_id": conversation_id,
             "chat_id": chat_id,
         }
-        return await self._requester.arequest("post", url, False, Chat, params=params)
+        return await self._requester.arequest("post", url, False, Chat, body=body)
 
     @property
     def messages(


### PR DESCRIPTION
- Changed chat.cancel API to accept parameters in request body instead of query params