### PR TITLE
feat: Implement template duplicate API with tests and examples

### DIFF
--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -84,6 +84,7 @@ from .model import (
     Stream,
 )
 from .request import AsyncHTTPClient, SyncHTTPClient
+from .templates import TemplateDuplicateRes, TemplateEntityType
 from .version import VERSION
 from .workflows.runs import (
     WorkflowEvent,
@@ -180,6 +181,9 @@ __all__ = [
     "WorkspaceRoleType",
     "WorkspaceType",
     "Workspace",
+    # templates
+    "TemplateDuplicateRes",
+    "TemplateEntityType",
     # log
     "setup_logging",
     # config

--- a/cozepy/coze.py
+++ b/cozepy/coze.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from .datasets import AsyncDatasetsClient, DatasetsClient
     from .files import AsyncFilesClient, FilesClient
     from .knowledge import AsyncKnowledgeClient, KnowledgeClient  # deprecated
+    from .templates import AsyncTemplatesClient, TemplatesClient
     from .workflows import AsyncWorkflowsClient, WorkflowsClient
     from .workspaces import AsyncWorkspacesClient, WorkspacesClient
 
@@ -39,6 +40,7 @@ class Coze(object):
         self._knowledge: Optional[KnowledgeClient] = None  # deprecated
         self._datasets: Optional[DatasetsClient] = None
         self._audio: Optional[AudioClient] = None
+        self._templates: Optional[TemplatesClient] = None
 
     @property
     def bots(self) -> "BotsClient":
@@ -118,6 +120,14 @@ class Coze(object):
             self._audio = AudioClient(self._base_url, self._auth, self._requester)
         return self._audio
 
+    @property
+    def templates(self) -> "TemplatesClient":
+        if not self._templates:
+            from .templates import TemplatesClient
+
+            self._templates = TemplatesClient(self._base_url, self._auth, self._requester)
+        return self._templates
+
 
 class AsyncCoze(object):
     def __init__(
@@ -140,6 +150,7 @@ class AsyncCoze(object):
         self._workflows: Optional[AsyncWorkflowsClient] = None
         self._workspaces: Optional[AsyncWorkspacesClient] = None
         self._audio: Optional[AsyncAudioClient] = None
+        self._templates: Optional[AsyncTemplatesClient] = None
 
     @property
     def bots(self) -> "AsyncBotsClient":
@@ -218,3 +229,11 @@ class AsyncCoze(object):
 
             self._audio = AsyncAudioClient(self._base_url, self._auth, self._requester)
         return self._audio
+
+    @property
+    def templates(self) -> "AsyncTemplatesClient":
+        if not self._templates:
+            from .templates import AsyncTemplatesClient
+
+            self._templates = AsyncTemplatesClient(self._base_url, self._auth, self._requester)
+        return self._templates

--- a/cozepy/templates/__init__.py
+++ b/cozepy/templates/__init__.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Awaitable, Optional
+from typing import Optional
 
 from cozepy.auth import Auth
 from cozepy.model import CozeModel
@@ -42,7 +42,7 @@ class AsyncTemplatesClient(object):
 
     async def duplicate(
         self, *, template_id: str, workspace_id: str, name: Optional[str] = None, **kwargs
-    ) -> Awaitable[TemplateDuplicateRes]:
+    ) -> TemplateDuplicateRes:
         url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
         headers: Optional[dict] = kwargs.get("headers")
         body = {

--- a/cozepy/templates/__init__.py
+++ b/cozepy/templates/__init__.py
@@ -1,0 +1,48 @@
+from enum import Enum
+from typing import Optional
+
+from cozepy.auth import Auth
+from cozepy.model import CozeModel
+from cozepy.request import Requester
+from cozepy.util import remove_url_trailing_slash
+
+
+class TemplateEntityType(str, Enum):
+    AGENT = "agent"
+
+
+class TemplateDuplicateRes(CozeModel):
+    entity_id: str
+    entity_type: TemplateEntityType
+
+
+class TemplatesClient(object):
+    def __init__(self, base_url: str, auth: Auth, requester: Requester):
+        self._base_url = remove_url_trailing_slash(base_url)
+        self._auth = auth
+        self._requester = requester
+
+    def duplicate(self, *, template_id: str, workspace_id: str, name: str, **kwargs) -> TemplateDuplicateRes:
+        url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
+        headers: Optional[dict] = kwargs.get("headers")
+        body = {
+            "workspace_id": workspace_id,
+            "name": name,
+        }
+        return self._requester.request("post", url, False, TemplateDuplicateRes, headers=headers, body=body)
+
+
+class AsyncTemplatesClient(object):
+    def __init__(self, base_url: str, auth: Auth, requester: Requester):
+        self._base_url = remove_url_trailing_slash(base_url)
+        self._auth = auth
+        self._requester = requester
+
+    async def duplicate(self, *, template_id: str, workspace_id: str, name: str, **kwargs) -> TemplateDuplicateRes:
+        url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
+        headers: Optional[dict] = kwargs.get("headers")
+        body = {
+            "workspace_id": workspace_id,
+            "name": name,
+        }
+        return self._requester.arequest("post", url, False, TemplateDuplicateRes, headers=headers, body=body)

--- a/cozepy/templates/__init__.py
+++ b/cozepy/templates/__init__.py
@@ -49,4 +49,4 @@ class AsyncTemplatesClient(object):
             "workspace_id": workspace_id,
             "name": name,
         }
-        return self._requester.arequest("post", url, False, TemplateDuplicateRes, headers=headers, body=body)
+        return await self._requester.arequest("post", url, False, TemplateDuplicateRes, headers=headers, body=body)

--- a/cozepy/templates/__init__.py
+++ b/cozepy/templates/__init__.py
@@ -22,7 +22,9 @@ class TemplatesClient(object):
         self._auth = auth
         self._requester = requester
 
-    def duplicate(self, *, template_id: str, workspace_id: str, name: str, **kwargs) -> TemplateDuplicateRes:
+    def duplicate(
+        self, *, template_id: str, workspace_id: str, name: Optional[str] = None, **kwargs
+    ) -> TemplateDuplicateRes:
         url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
         headers: Optional[dict] = kwargs.get("headers")
         body = {
@@ -38,7 +40,9 @@ class AsyncTemplatesClient(object):
         self._auth = auth
         self._requester = requester
 
-    async def duplicate(self, *, template_id: str, workspace_id: str, name: str, **kwargs) -> TemplateDuplicateRes:
+    async def duplicate(
+        self, *, template_id: str, workspace_id: str, name: Optional[str] = None, **kwargs
+    ) -> TemplateDuplicateRes:
         url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
         headers: Optional[dict] = kwargs.get("headers")
         body = {

--- a/cozepy/templates/__init__.py
+++ b/cozepy/templates/__init__.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Awaitable, Optional
 
 from cozepy.auth import Auth
 from cozepy.model import CozeModel
@@ -42,7 +42,7 @@ class AsyncTemplatesClient(object):
 
     async def duplicate(
         self, *, template_id: str, workspace_id: str, name: Optional[str] = None, **kwargs
-    ) -> TemplateDuplicateRes:
+    ) -> Awaitable[TemplateDuplicateRes]:
         url = f"{self._base_url}/v1/templates/{template_id}/duplicate"
         headers: Optional[dict] = kwargs.get("headers")
         body = {

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -201,15 +201,13 @@ class RichWorkspaceList(object):
         self._size = size
         self._json_output = json_output
 
-    def __rich__(self) -> str:
+    def print(self):
         if self._json_output:
-            return self._get_json()
+            print(self._get_json())
+            return
         table = self._get_table()
-        table.add_section()
-        table.add_row(
-            f"Total: {self._total} | Page: {self._page} | Size: {self._size}", style="bold cyan", end_section=True
-        )
-        return table
+        console.print(table)
+        console.print(f"Total: {self._total} | Page: {self._page} | Size: {self._size}")
 
     def _get_table(self) -> Table:
         table = Table(show_header=True, header_style="bold magenta")
@@ -360,8 +358,7 @@ class CozeAPI(object):
         if name_filter:
             workspaces = [ws for ws in workspaces if name_filter.lower() in ws.name.lower()]
 
-        rich_workspace_list = RichWorkspaceList(workspaces, total, page, size, json_output)
-        console.print(rich_workspace_list)
+        RichWorkspaceList(workspaces, total, page, size, json_output).print()
 
     def list_bots(
         self,
@@ -623,11 +620,15 @@ def template():
 def duplicate_template(template_id: str, workspace_id: str, name: Optional[str]):
     """Duplicate a template"""
     try:
-        res = coze.templates.duplicate(template_id=template_id, workspace_id=workspace_id, name=name)
+        res = coze._auth.client().templates.duplicate(
+            template_id=template_id,
+            workspace_id=workspace_id,
+            name=name,
+            headers={"x-tt-env": "ppe_volcengine", "x-use-ppe": "1"},
+        )
+        console.print(f"[green]Template duplicated: {res.entity_id}, {res.entity_type}[/green]")
     except Exception as e:
         console.print(f"[red]Error: {str(e)}[/red]")
-
-    console.print(f"[green]Template duplicated: {res.entity_id}, {res.entity_type}[/green]")
 
 
 if __name__ == "__main__":

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -144,7 +144,7 @@ class DeviceAuth(object):
         """Get new token"""
         try:
             device_code = self._oauth_app.get_device_code()
-            print("Please open url:", device_code.verification_url)
+            console.print(f"[yellow]Please open url: {device_code.verification_url}[/yellow]")
             return self._oauth_app.get_access_token(device_code.device_code, poll=True)
         except Exception:
             return None
@@ -329,6 +329,10 @@ class CozeAPI(object):
         self._auth = DeviceAuth()
         self._file_cache = FileCache(".cache")
 
+    def logout(self):
+        for file in os.listdir(".cache"):
+            os.remove(os.path.join(".cache", file))
+
     def list_workspaces(
         self,
         page: int = 1,
@@ -497,6 +501,14 @@ coze = CozeAPI()
 def cli():
     """Coze CLI"""
     pass
+
+
+# logout or auth revoke
+@cli.command("logout")
+def logout():
+    """Logout"""
+    coze.logout()
+    console.print("[green]Logout successfully[/green]")
 
 
 @cli.group()

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -636,7 +636,6 @@ def duplicate_template(template_id: str, workspace_id: str, name: Optional[str])
             template_id=template_id,
             workspace_id=workspace_id,
             name=name,
-            headers={"x-tt-env": "ppe_volcengine", "x-use-ppe": "1"},
         )
         console.print(f"[green]Template duplicated: {res.entity_id}, {res.entity_type}[/green]")
     except Exception as e:

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -610,5 +610,25 @@ def create_speech(
         console.print(f"[red]Error: {str(e)}[/red]")
 
 
+@cli.group()
+def template():
+    """Template"""
+    pass
+
+
+@template.command("duplicate")
+@click.argument("template_id")
+@click.argument("workspace_id")
+@click.option("--name", "name", help="Template name")
+def duplicate_template(template_id: str, workspace_id: str, name: Optional[str]):
+    """Duplicate a template"""
+    try:
+        res = coze.templates.duplicate(template_id=template_id, workspace_id=workspace_id, name=name)
+    except Exception as e:
+        console.print(f"[red]Error: {str(e)}[/red]")
+
+    console.print(f"[green]Template duplicated: {res.entity_id}, {res.entity_type}[/green]")
+
+
 if __name__ == "__main__":
     cli()

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -10,7 +10,17 @@ from typing import List, Optional, Type, TypeVar
 
 from pydantic import BaseModel
 
-from cozepy import COZE_CN_BASE_URL, Bot, Coze, DeviceOAuthApp, OAuthToken, TokenAuth, Voice, Workspace
+from cozepy import (
+    COZE_CN_BASE_URL,
+    Bot,
+    Coze,
+    DeviceOAuthApp,
+    OAuthToken,
+    TemplateEntityType,
+    TokenAuth,
+    Voice,
+    Workspace,
+)
 from cozepy.log import setup_logging
 
 try:
@@ -638,6 +648,9 @@ def duplicate_template(template_id: str, workspace_id: str, name: Optional[str])
             name=name,
         )
         console.print(f"[green]Template duplicated: {res.entity_id}, {res.entity_type}[/green]")
+        if res.entity_type == TemplateEntityType.AGENT:
+            agent_url = f"https://www.coze.cn/space/{workspace_id}/bot/{res.entity_id}"
+            console.print(f"[green]Agent URL: {agent_url}[/green]")
     except Exception as e:
         console.print(f"[red]Error: {str(e)}[/red]")
 

--- a/examples/template_duplicate.py
+++ b/examples/template_duplicate.py
@@ -1,0 +1,27 @@
+"""
+This example demonstrates how to duplicate a template.
+"""
+
+import os
+
+from cozepy import Coze
+from cozepy.auth import TokenAuth
+from cozepy.config import COZE_COM_BASE_URL
+
+# Get an access_token through personal access token or oauth.
+coze_api_token = os.getenv("COZE_API_TOKEN")
+# The default access is api.coze.com, but if you need to access api.coze.cn,
+# please use base_url to configure the api endpoint to access
+coze_api_base = os.getenv("COZE_API_BASE") or COZE_COM_BASE_URL
+# workspace id
+workspace_id = os.getenv("COZE_WORKSPACE_ID")
+# template id
+template_id = os.getenv("COZE_TEMPLATE_ID")
+
+# Init the Coze client through the access_token.
+coze = Coze(auth=TokenAuth(token=coze_api_token), base_url=coze_api_base)
+
+
+res = coze.templates.duplicate(template_id=template_id, workspace_id=workspace_id)
+print("entity_id:", res.entity_id)
+print("entity_type:", res.entity_type)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 
 from cozepy import AsyncCoze, Coze, TemplateDuplicateRes, TokenAuth
-from cozepy.util import random_string
+from cozepy.util import random_hex
 
 
 def mock_template_duplicate(respx_mock, entity_id, entity_type):
@@ -24,8 +24,8 @@ class TestTemplate:
     def test_sync_template_duplicate(self, respx_mock):
         coze = Coze(auth=TokenAuth(token="token"))
 
-        entity_id = random_string(10)
-        entity_type = random_string(10)
+        entity_id = random_hex(10)
+        entity_type = random_hex(10)
 
         mock_template_duplicate(respx_mock, entity_id, entity_type)
 
@@ -41,8 +41,8 @@ class TestAsyncTemplate:
     async def test_async_template_duplicate(self, respx_mock):
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
-        entity_id = random_string(10)
-        entity_type = random_string(10)
+        entity_id = random_hex(10)
+        entity_type = random_hex(10)
 
         mock_template_duplicate(respx_mock, entity_id, entity_type)
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+
+from cozepy import AsyncCoze, Coze, TemplateDuplicateRes, TokenAuth
+from cozepy.util import random_string
+
+
+def mock_template_duplicate(respx_mock, entity_id, entity_type):
+    respx_mock.post("/v1/templates/template_id/duplicate").mock(
+        httpx.Response(
+            200,
+            json={
+                "data": TemplateDuplicateRes(
+                    entity_id=entity_id,
+                    entity_type=entity_type,
+                ).model_dump()
+            },
+        )
+    )
+
+
+@pytest.mark.respx(base_url="https://api.coze.com")
+class TestTemplate:
+    def test_sync_template_duplicate(self, respx_mock):
+        coze = Coze(auth=TokenAuth(token="token"))
+
+        entity_id = random_string(10)
+        entity_type = random_string(10)
+
+        mock_template_duplicate(respx_mock, entity_id, entity_type)
+
+        res = coze.templates.duplicate(template_id="template_id", workspace_id="workspace_id", name="name")
+        assert res
+        assert res.entity_id == entity_id
+        assert res.entity_type == entity_type
+
+
+@pytest.mark.respx(base_url="https://api.coze.com")
+@pytest.mark.asyncio
+class TestAsyncTemplate:
+    async def test_async_template_duplicate(self, respx_mock):
+        coze = AsyncCoze(auth=TokenAuth(token="token"))
+
+        entity_id = random_string(10)
+        entity_type = random_string(10)
+
+        mock_template_duplicate(respx_mock, entity_id, entity_type)
+
+        res = await coze.templates.duplicate(template_id="template_id", workspace_id="workspace_id", name="name")
+        assert res
+        assert res.entity_id == entity_id
+        assert res.entity_type == entity_type

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -25,7 +25,7 @@ class TestTemplate:
         coze = Coze(auth=TokenAuth(token="token"))
 
         entity_id = random_hex(10)
-        entity_type = random_hex(10)
+        entity_type = "agent"
 
         mock_template_duplicate(respx_mock, entity_id, entity_type)
 
@@ -42,7 +42,7 @@ class TestAsyncTemplate:
         coze = AsyncCoze(auth=TokenAuth(token="token"))
 
         entity_id = random_hex(10)
-        entity_type = random_hex(10)
+        entity_type = "agent"
 
         mock_template_duplicate(respx_mock, entity_id, entity_type)
 


### PR DESCRIPTION
- Add new API endpoint for template duplicate functionality
- Implement unit tests to ensure reliability of the new feature
- Create usage examples to demonstrate the template copying process