### PR TITLE
fix: CI fails on python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.7","3.8", "3.9", "3.10", "3.11", "3.12" ]
-        os: [ "ubuntu-latest" ]
+        os: [ "ubuntu-22.04" ]
         os-label: [ "Ubuntu" ]
         include:
           - { python-version: "3.8", os: "windows-latest", os-label: "Windows" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7","3.8", "3.9", "3.10", "3.11", "3.12" ]
-        os: [ "ubuntu-22.04" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        os: [ "ubuntu-latest" ]
         os-label: [ "Ubuntu" ]
         include:
           - { python-version: "3.8", os: "windows-latest", os-label: "Windows" }
           - { python-version: "3.8", os: "macos-latest", os-label: "macOS" }
+          - { python-version: "3.7", os: "ubuntu-22.04", os-label: "Ubuntu" }
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Ubuntu 22.04
	- Minor syntax refinement in CI configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->