### PR TITLE
feat: add missed app_id for workflow

### DIFF
--- a/cozepy/workflows/runs/__init__.py
+++ b/cozepy/workflows/runs/__init__.py
@@ -199,6 +199,7 @@ class WorkflowsRunsClient(object):
         workflow_id: str,
         parameters: Optional[Dict[str, Any]] = None,
         bot_id: Optional[str] = None,
+        app_id: Optional[str] = None,
         ext: Optional[Dict[str, Any]] = None,
     ) -> Stream[WorkflowEvent]:
         """
@@ -219,6 +220,7 @@ class WorkflowsRunsClient(object):
         body = {
             "workflow_id": workflow_id,
             "parameters": parameters,
+            "app_id": app_id,
             "bot_id": bot_id,
             "ext": ext,
         }


### PR DESCRIPTION
Pretty straight forward change. Currently the demo code (https://www.coze.com/open/playground/workflow_run), Python section, gives an error:

got error error_code=4000 error_message='App not found. Please verify the app_id is correct and ensure the app has been published.'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional `app_id` parameter to workflow streaming methods, providing more flexibility in specifying application context for workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->