### PR TITLE
fix: Add 'data' field of type Message to ConversationMessageCompletedEvent class

### DIFF
--- a/cozepy/websockets/chat/__init__.py
+++ b/cozepy/websockets/chat/__init__.py
@@ -109,6 +109,7 @@ class ConversationAudioTranscriptCompletedEvent(WebsocketsEvent):
 # resp
 class ConversationMessageCompletedEvent(WebsocketsEvent):
     event_type: WebsocketsEventType = WebsocketsEventType.CONVERSATION_MESSAGE_COMPLETED
+    data: Message
 
 
 # resp
@@ -300,6 +301,7 @@ class WebsocketsChatClient(WebsocketsBaseClient):
                 {
                     "id": event_id,
                     "detail": detail,
+                    "data": Message.model_validate(data),
                 }
             )
         elif event_type == WebsocketsEventType.CONVERSATION_AUDIO_DELTA.value:
@@ -535,6 +537,7 @@ class AsyncWebsocketsChatClient(AsyncWebsocketsBaseClient):
                 {
                     "id": event_id,
                     "detail": detail,
+                    "data": Message.model_validate(data),
                 }
             )
         elif event_type == WebsocketsEventType.CONVERSATION_AUDIO_DELTA.value:


### PR DESCRIPTION
- Add 'data' field of type Message to ConversationMessageCompletedEvent class
- Implement data validation using Message.model_validate(data) for both WebsocketsChatClient and AsyncWebsocketsChatClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of conversation message events to ensure message data is properly processed and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->