### PR TITLE
chore: Fix import error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,9 +514,9 @@ Asynchronous calls also support streaming mode:
 import os
 import asyncio
 
-from cozepy import TokenAuth, ChatEventType, Message, AsyncCoze
+from cozepy import AsyncTokenAuth, ChatEventType, Message, AsyncCoze
 
-coze = AsyncCoze(auth=TokenAuth(os.getenv("COZE_API_TOKEN")))
+coze = AsyncCoze(auth=AsyncTokenAuth(os.getenv("COZE_API_TOKEN")))
 
 
 async def main():


### PR DESCRIPTION
When using the demo, I encountered an import error. It should use AsyncTokenAuth in the AsyncCoze function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the asynchronous streaming example in the README to use the correct asynchronous authentication class for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->