### PR TITLE
feat: Add input_text.generate_audio event for WebSocket chat API

### DIFF
--- a/cozepy/__init__.py
+++ b/cozepy/__init__.py
@@ -193,6 +193,7 @@ from .websockets.chat import (
     ConversationMessageDeltaEvent,
     InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
+    InputTextGenerateAudioEvent,
     WebsocketsChatClient,
     WebsocketsChatEventHandler,
 )
@@ -395,6 +396,7 @@ __all__ = [
     "ConversationClear",
     "ConversationChatSubmitToolOutputsEvent",
     "ConversationChatCancelEvent",
+    "InputTextGenerateAudioEvent",
     "ChatCreatedEvent",
     "ChatUpdatedEvent",
     "ConversationChatCreatedEvent",

--- a/cozepy/websockets/chat/__init__.py
+++ b/cozepy/websockets/chat/__init__.py
@@ -198,15 +198,15 @@ class InputTextGenerateAudioEvent(WebsocketsEvent):
     你可以主动提交一段文字用来做语音合成，提交的消息不会触发智能体的回复，只会合成音频内容下发到客户端。
     提交事件的时候如果智能体正在输出语音会被中断输出。适合在和智能体聊天过程中客户端长时间没有响应，
     智能体可以主动说话暖场的场景。
-    docs: https://www.coze.cn/open/docs/developer_guides/streaming_chat_event#input_text_generate_audio
+    docs: https://www.coze.cn/open/docs/developer_guides/streaming_chat_event#620367d0
     """
 
-    class ContentMode(DynamicStrEnum):
+    class Mode(DynamicStrEnum):
         TEXT = "text"
 
     class Data(BaseModel):
         # 消息内容的类型，支持设置为：text：文本
-        mode: "InputTextGenerateAudioEvent.ContentMode"
+        mode: "InputTextGenerateAudioEvent.Mode"
         # 当 mode == text 时候必填。长度限制 (0, 1024) 字节
         text: Optional[str] = None
 

--- a/cozepy/websockets/ws.py
+++ b/cozepy/websockets/ws.py
@@ -96,6 +96,7 @@ class WebsocketsEventType(DynamicStrEnum):
     CONVERSATION_CLEAR = "conversation.clear"  # 清除上下文
     CONVERSATION_CHAT_SUBMIT_TOOL_OUTPUTS = "conversation.chat.submit_tool_outputs"  # 提交端插件执行结果
     CONVERSATION_CHAT_CANCEL = "conversation.chat.cancel"  # 打断智能体输出
+    INPUT_TEXT_GENERATE_AUDIO = "input_text.generate_audio"  # 提交文字用于语音合成
     # resp
     CHAT_CREATED = "chat.created"  # 对话连接成功
     CHAT_UPDATED = "chat.updated"  # 对话配置成功


### PR DESCRIPTION
Add support for the new `input_text.generate_audio` event type that allows clients to submit text for speech synthesis without triggering agent responses. This is useful for scenarios where the agent needs to proactively speak when the client has been silent for a long time.

Changes:
- Add INPUT_TEXT_GENERATE_AUDIO event type in WebsocketsEventType
- Add InputTextGenerateAudioEvent class with proper validation
- Add input_text_generate_audio() methods to both WebsocketsChatClient and AsyncWebsocketsChatClient
- Include ContentMode enum for text mode validation

Usage example:
```python
event_data = InputTextGenerateAudioEvent.Data(
    mode=InputTextGenerateAudioEvent.ContentMode.TEXT,
    text="Hello, are you still there?"
)
client.input_text_generate_audio(event_data)
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for submitting text for speech synthesis without triggering an agent reply via a new event type.
  * Introduced new methods for both synchronous and asynchronous clients to enable submitting text for audio generation through the websocket interface.

* **Chores**
  * Exposed the new event type for public use in the package’s exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->