### PR TITLE
feat: Add is_output_trimmed field to WorkflowRunHistory model

### DIFF
--- a/cozepy/workflows/runs/run_histories/__init__.py
+++ b/cozepy/workflows/runs/run_histories/__init__.py
@@ -105,6 +105,9 @@ class WorkflowRunHistory(CozeModel):
     # 此处大模型返回的消耗 Token 仅供参考，以火山引擎账单实际为准。
     usage: Optional[ChatUsage] = None
 
+    # 标识工作流的输出内容是否因过大而不完整。
+    is_output_trimmed: bool
+
     @field_validator("error_code", mode="before")
     @classmethod
     def error_code_empty_str_to_zero(cls, v):

--- a/tests/test_workflow_run_history.py
+++ b/tests/test_workflow_run_history.py
@@ -17,6 +17,7 @@ def test_empty_str_to_zero():
         "output": '{"Output":"null"}',
         "cost": "0.00000",
         "error_code": "",
+        "is_output_trimmed": False,
     }
     history = WorkflowRunHistory(**data)
     assert history.error_code == 0

--- a/tests/test_workflows_runs.py
+++ b/tests/test_workflows_runs.py
@@ -77,6 +77,7 @@ def mock_create_workflows_runs_run_histories_retrieve(respx_mock):
         error_code=0,
         error_message="error_message",
         debug_url="debug_url",
+        is_output_trimmed=False,
     )
     workflow_run_result._raw_response = httpx.Response(
         200,


### PR DESCRIPTION
- Added is_output_trimmed boolean field to indicate when workflow output is truncated due to size limits

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an indicator to show if a workflow's output content is incomplete due to size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->