### PR TITLE
feat: add conversation update API support

### DIFF
--- a/cozepy/conversations/__init__.py
+++ b/cozepy/conversations/__init__.py
@@ -12,6 +12,10 @@ class Conversation(CozeModel):
     meta_data: Dict[str, str]
     # section_id is used to distinguish the context sections of the session history. The same section is one context.
     last_section_id: str
+    name: Optional[str] = None
+    updated_at: Optional[int] = None
+    creator_id: Optional[str] = None
+    connector_id: Optional[str] = None
 
 
 class Section(CozeModel):
@@ -114,8 +118,30 @@ class ConversationsClient(object):
         return self._requester.request("get", url, False, Conversation, params=params)
 
     def clear(self, *, conversation_id: str) -> Section:
+        """
+        清空会话内容。
+        清空指定会话的所有消息内容，但保留会话本身。
+
+        :param conversation_id: 会话ID
+        :return: Section对象
+        """
         url = f"{self._base_url}/v1/conversations/{conversation_id}/clear"
         return self._requester.request("post", url, False, Section)
+
+    def update(self, *, conversation_id: str, name: Optional[str] = None) -> Conversation:
+        """
+        更新会话信息。
+        更新指定会话的名称，便于识别与管理。
+
+        docs: https://www.coze.cn/docs/developer_guides/edit_conversation
+
+        :param conversation_id: 会话ID
+        :param name: 新的会话名称，最多100个字符
+        :return: 更新后的Conversation对象
+        """
+        url = f"{self._base_url}/v1/conversations/{conversation_id}"
+        body = {"name": name}
+        return self._requester.request("put", url, False, Conversation, body=body)
 
     @property
     def messages(self):
@@ -207,8 +233,30 @@ class AsyncConversationsClient(object):
         return await self._requester.arequest("get", url, False, Conversation, params=params)
 
     async def clear(self, *, conversation_id: str) -> Section:
+        """
+        清空会话内容。
+        清空指定会话的所有消息内容，但保留会话本身。
+
+        :param conversation_id: 会话ID
+        :return: Section对象
+        """
         url = f"{self._base_url}/v1/conversations/{conversation_id}/clear"
         return await self._requester.arequest("post", url, False, Section)
+
+    async def update(self, *, conversation_id: str, name: Optional[str] = None) -> Conversation:
+        """
+        更新会话信息。
+        更新指定会话的名称，便于识别与管理。
+
+        docs: https://www.coze.cn/docs/developer_guides/edit_conversation
+
+        :param conversation_id: 会话ID
+        :param name: 新的会话名称，最多100个字符
+        :return: 更新后的Conversation对象
+        """
+        url = f"{self._base_url}/v1/conversations/{conversation_id}"
+        body = {"name": name}
+        return await self._requester.arequest("put", url, False, Conversation, body=body)
 
     @property
     def messages(self):

--- a/examples/conversation_update.py
+++ b/examples/conversation_update.py
@@ -1,0 +1,59 @@
+"""
+示例：更新会话名称
+
+本示例演示如何使用Coze SDK更新指定会话的名称。
+"""
+
+import logging
+import os
+from typing import Optional
+
+from cozepy import COZE_CN_BASE_URL, Coze, DeviceOAuthApp, TokenAuth, setup_logging
+
+
+def get_coze_api_base() -> str:
+    # The default access is api.coze.cn, but if you need to access api.coze.com,
+    # please use base_url to configure the api endpoint to access
+    coze_api_base = os.getenv("COZE_API_BASE")
+    if coze_api_base:
+        return coze_api_base
+
+    return COZE_CN_BASE_URL  # default
+
+
+def get_coze_api_token(workspace_id: Optional[str] = None) -> str:
+    # Get an access_token through personal access token or oauth.
+    coze_api_token = os.getenv("COZE_API_TOKEN")
+    if coze_api_token:
+        return coze_api_token
+
+    coze_api_base = get_coze_api_base()
+
+    device_oauth_app = DeviceOAuthApp(client_id="57294420732781205987760324720643.app.coze", base_url=coze_api_base)
+    device_code = device_oauth_app.get_device_code(workspace_id)
+    print(f"Please Open: {device_code.verification_url} to get the access token")
+    return device_oauth_app.get_access_token(device_code=device_code.device_code, poll=True).access_token
+
+
+# Init the Coze client through the access_token.
+coze = Coze(auth=TokenAuth(token=get_coze_api_token()), base_url=get_coze_api_base())
+# coze bot id
+coze_bot_id = os.getenv("COZE_BOT_ID") or "input your bot id"
+conversation_id = os.getenv("COZE_CONVERSATION_ID") or "your_conversation_id"
+# Whether to print detailed logs
+is_debug = os.getenv("DEBUG")
+
+if is_debug:
+    setup_logging(logging.DEBUG)
+
+# 示例：更新会话名称
+# 假设我们有一个会话ID
+new_name = "新的会话名称"
+
+# 更新会话名称
+updated_conversation = coze.conversations.update(conversation_id=conversation_id, name=new_name)
+
+print("会话更新成功：")
+print(f"会话ID: {updated_conversation.id}")
+print(f"新名称: {updated_conversation.name}")
+print(f"更新时间: {updated_conversation.updated_at}")

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -79,6 +79,19 @@ def mock_clear_conversation(respx_mock) -> Section:
     return section
 
 
+def mock_update_conversation(respx_mock) -> Conversation:
+    conversation = make_conversation()
+    conversation.name = "updated_conversation_name"
+    conversation.updated_at = int(time.time())
+    conversation._raw_response = httpx.Response(
+        200,
+        json={"data": conversation.model_dump()},
+        headers={logid_key(): random_hex(10)},
+    )
+    respx_mock.put(f"/v1/conversations/{conversation.id}").mock(conversation._raw_response)
+    return conversation
+
+
 @pytest.mark.respx(base_url="https://api.coze.com")
 class TestSyncConversation:
     def test_sync_conversations_create(self, respx_mock):
@@ -146,6 +159,18 @@ class TestSyncConversation:
         assert res.response.logid == mock_section.response.logid
         assert res.id == mock_section.id
         assert res.conversation_id == mock_section.conversation_id
+
+    def test_sync_conversations_update(self, respx_mock):
+        coze = Coze(auth=TokenAuth(token="token"))
+
+        mock_conversation = mock_update_conversation(respx_mock)
+
+        res = coze.conversations.update(conversation_id=mock_conversation.id, name="updated_conversation_name")
+        assert res
+        assert res.response.logid == mock_conversation.response.logid
+        assert res.id == mock_conversation.id
+        assert res.name == mock_conversation.name
+        assert res.updated_at == mock_conversation.updated_at
 
 
 @pytest.mark.respx(base_url="https://api.coze.com")
@@ -216,3 +241,15 @@ class TestAsyncConversation:
         assert res.response.logid == mock_section.response.logid
         assert res.id == mock_section.id
         assert res.conversation_id == mock_section.conversation_id
+
+    async def test_async_conversations_update(self, respx_mock):
+        coze = AsyncCoze(auth=AsyncTokenAuth(token="token"))
+
+        mock_conversation = mock_update_conversation(respx_mock)
+
+        res = await coze.conversations.update(conversation_id=mock_conversation.id, name="updated_conversation_name")
+        assert res
+        assert res.response.logid == mock_conversation.response.logid
+        assert res.id == mock_conversation.id
+        assert res.name == mock_conversation.name
+        assert res.updated_at == mock_conversation.updated_at


### PR DESCRIPTION
- Add update method to ConversationsClient for editing conversation names
- Add async update method to AsyncConversationsClient
- Add comprehensive unit tests for both sync and async update functionality
- Add usage examples for conversation update API
- Update Conversation model to include new fields (name, updated_at, creator_id, connector_id)

API endpoint: PUT /v1/conversations/:conversation_id
Documentation: https://www.coze.cn/docs/developer_guides/edit_conversation

🤖 Generated with [Claude Code](https://claude.ai/code)