### PR TITLE
chore: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 on:
   push:
     tags: ["v*.*.*"]


### PR DESCRIPTION
Potential fix for [https://github.com/coze-dev/coze-py/security/code-scanning/1](https://github.com/coze-dev/coze-py/security/code-scanning/1)

To fix the issue, explicitly add a `permissions` key at the appropriate level in the workflow. Since the minimal required permissions for publishing to PyPI do not require writing to the repository, set `contents: read` as the least privilege. This can be added either at the top workflow level (so it applies to all jobs) or to the relevant job (`publish`). For clarity and future extensibility, adding the block at the workflow root level is preferred. Only the `.github/workflows/pypi-release.yml` file needs to be edited, with the following block added after the workflow `name` and before `on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI release workflow by adding a top-level permissions block that restricts the GitHub Actions token to read-only repository contents.
  * Workflow triggers, jobs, and steps are unchanged; no effect on build or publish behavior.
  * Improves adherence to least privilege and aligns with GitHub Actions security recommendations. No user-facing changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->