### PR TITLE
Update websockets

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2616,4 +2616,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.7"
-content-hash = "a4002e05f519c4803e5bdfe6ebaed8d893bfc2bb98a7db2246063501109ada48"
+content-hash = "24f69354768a5e1f386c91570ed2b7077d637a1e9c15ea8a2979d826b1ccb767"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ httpx = [
 typing-extensions = "^4.3.0"
 distro = "^1.9.0"
 websockets = [
-    { version = ">=14.1.0, <16.0.0", python = ">=3.9" },
+    { version = ">=14.1.0", python = ">=3.9" },
     { version = "^13.1.0", python = ">=3.8,<3.9" },
     { version = "^11.0.3", python = ">=3.7,<3.8" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed the websocket dependency version constraint to allow 14.1.0 and later on Python 3.9+.
  * No other dependencies or configuration were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->