### PR TITLE
chore: sync sdk output for unified single-file upload guard

### DIFF
--- a/cozepy/audio/transcriptions/__init__.py
+++ b/cozepy/audio/transcriptions/__init__.py
@@ -31,7 +31,7 @@ class TranscriptionsClient(object):
         """
         url = f"{self._base_url}/v1/audio/transcriptions"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return self._requester.request("post", url, False, cast=CreateTranscriptionsResp, headers=headers, files=files)
 
 
@@ -60,7 +60,7 @@ class AsyncTranscriptionsClient(object):
         """
         url = f"{self._base_url}/v1/audio/transcriptions"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return await self._requester.arequest(
             "post", url, False, cast=CreateTranscriptionsResp, headers=headers, files=files
         )

--- a/cozepy/audio/voiceprint_groups/__init__.py
+++ b/cozepy/audio/voiceprint_groups/__init__.py
@@ -169,7 +169,6 @@ class VoiceprintGroupsClient(object):
     ) -> SpeakerIdentifyResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/speaker_identify"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
         body = remove_none_values(
             {
                 "top_k": top_k,
@@ -177,6 +176,7 @@ class VoiceprintGroupsClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)}
         return self._requester.request(
             "post", url, False, cast=SpeakerIdentifyResp, headers=headers, body=body, files=files
         )
@@ -294,7 +294,6 @@ class AsyncVoiceprintGroupsClient(object):
     ) -> SpeakerIdentifyResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/speaker_identify"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
         body = remove_none_values(
             {
                 "top_k": top_k,
@@ -302,6 +301,7 @@ class AsyncVoiceprintGroupsClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)}
         return await self._requester.arequest(
             "post", url, False, cast=SpeakerIdentifyResp, headers=headers, body=body, files=files
         )

--- a/cozepy/audio/voiceprint_groups/__init__.py
+++ b/cozepy/audio/voiceprint_groups/__init__.py
@@ -176,7 +176,7 @@ class VoiceprintGroupsClient(object):
                 "channel": channel,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return self._requester.request(
             "post", url, False, cast=SpeakerIdentifyResp, headers=headers, body=body, files=files
         )
@@ -301,7 +301,7 @@ class AsyncVoiceprintGroupsClient(object):
                 "channel": channel,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return await self._requester.arequest(
             "post", url, False, cast=SpeakerIdentifyResp, headers=headers, body=body, files=files
         )

--- a/cozepy/audio/voiceprint_groups/features/__init__.py
+++ b/cozepy/audio/voiceprint_groups/features/__init__.py
@@ -69,7 +69,6 @@ class VoiceprintGroupsFeaturesClient(object):
     ) -> CreateVoicePrintGroupFeatureResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/features"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
         body = remove_none_values(
             {
                 "name": name,
@@ -78,6 +77,7 @@ class VoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)}
         return self._requester.request(
             "post", url, False, cast=CreateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )
@@ -96,7 +96,6 @@ class VoiceprintGroupsFeaturesClient(object):
     ) -> UpdateVoicePrintGroupFeatureResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/features/{feature_id}"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)} if file else {}
         body = remove_none_values(
             {
                 "name": name,
@@ -105,6 +104,7 @@ class VoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)} if file else {}
         return self._requester.request(
             "put", url, False, cast=UpdateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )
@@ -166,7 +166,6 @@ class AsyncVoiceprintGroupsFeaturesClient(object):
     ) -> CreateVoicePrintGroupFeatureResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/features"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)}
         body = remove_none_values(
             {
                 "name": name,
@@ -175,6 +174,7 @@ class AsyncVoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)}
         return await self._requester.arequest(
             "post", url, False, cast=CreateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )
@@ -193,7 +193,6 @@ class AsyncVoiceprintGroupsFeaturesClient(object):
     ) -> UpdateVoicePrintGroupFeatureResp:
         url = f"{self._base_url}/v1/audio/voiceprint_groups/{group_id}/features/{feature_id}"
         headers: Optional[dict] = kwargs.get("headers")
-        files = {"file": _try_fix_file(file)} if file else {}
         body = remove_none_values(
             {
                 "name": name,
@@ -202,6 +201,7 @@ class AsyncVoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
+        files = {"file": _try_fix_file(file)} if file else {}
         return await self._requester.arequest(
             "put", url, False, cast=UpdateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )

--- a/cozepy/audio/voiceprint_groups/features/__init__.py
+++ b/cozepy/audio/voiceprint_groups/features/__init__.py
@@ -77,7 +77,7 @@ class VoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return self._requester.request(
             "post", url, False, cast=CreateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )
@@ -174,7 +174,7 @@ class AsyncVoiceprintGroupsFeaturesClient(object):
                 "channel": channel,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return await self._requester.arequest(
             "post", url, False, cast=CreateVoicePrintGroupFeatureResp, headers=headers, body=body, files=files
         )

--- a/cozepy/audio/voices/__init__.py
+++ b/cozepy/audio/voices/__init__.py
@@ -140,7 +140,7 @@ class VoicesClient(object):
                 "description": description,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return self._requester.request("post", url, False, cast=Voice, headers=headers, body=body, files=files)
 
     def list(
@@ -265,7 +265,7 @@ class AsyncVoicesClient(object):
                 "description": description,
             }
         )
-        files = {"file": _try_fix_file(file)}
+        files = {"file": _try_fix_file(file)} if file else {}
         return await self._requester.arequest("post", url, False, cast=Voice, headers=headers, body=body, files=files)
 
     async def list(


### PR DESCRIPTION
## Summary
- sync generated Python SDK output after upstream optimization in `coze-sdk-gen` for single-file upload rendering
- unify all single-file upload assignments to:
  - `files = {"file": _try_fix_file(file)} if file else {}`
- this removes the previous inconsistency where required file fields used unconditional assignment while optional file fields used conditional assignment

## Generator change
- upstream generator PR: https://github.com/coze-dev/coze-sdk-gen/pull/65

## Changed SDK files
- cozepy/audio/transcriptions/__init__.py
- cozepy/audio/voices/__init__.py
- cozepy/audio/voiceprint_groups/__init__.py
- cozepy/audio/voiceprint_groups/features/__init__.py

## Validation
- from coze-sdk-gen repo:
  - ./scripts/genpy.sh --output-sdk exist-repo/coze-py --ci-check
- coze-py checks passed in ci-check:
  - poetry build
  - poetry run ruff check cozepy
  - poetry run ruff format --check
  - poetry run mypy .
  - poetry run pytest --cov --cov-report=xml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted multipart handling across voiceprint groups, audio features, transcriptions, and voice clone operations to include file data only when a file is provided, reducing unnecessary payloads.
* **Chore**
  * Minor internal cleanup improving request construction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->